### PR TITLE
Fix autocomplete

### DIFF
--- a/Model/Autocomplete/DataProvider/AutocompleteDataProvider.php
+++ b/Model/Autocomplete/DataProvider/AutocompleteDataProvider.php
@@ -94,7 +94,7 @@ class AutocompleteDataProvider implements DataProviderInterface
      */
     public function isSupported(): bool
     {
-        return $this->config->isAutocompleteEnabled();
+        return ($this->config->isAutocompleteEnabled() && !$this->config->isSuggestionsAutocomplete());
     }
 
     /**

--- a/Model/Client/Type/SuggestionType/SuggestionTypeCategory.php
+++ b/Model/Client/Type/SuggestionType/SuggestionTypeCategory.php
@@ -2,9 +2,8 @@
 
 namespace Tweakwise\Magento2Tweakwise\Model\Client\Type\SuggestionType;
 
-use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
-use Tweakwise\Magento2TweakwiseExport\Model\Config;
+use Tweakwise\Magento2Tweakwise\Model\Config;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryRepository;
 use Magento\Framework\Exception\NoSuchEntityException;


### PR DESCRIPTION
This pull requests fixes 2 bugs

1) Old autocomplete api is still called when new suggestion api is enabled.

2) When using the suggetions api, if the result contains an category you get an 500 error. Because the function showAutocompleteParentCategories doesn't exists. This is caused by an wrong use statement.