### PR TITLE
Hyva theme personal merchandising

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -367,11 +367,13 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
         }
 
         // Add this only for ajax requests
-        if ($this->tweakwiseConfig->isPersonalMerchandisingActive() && $request->isAjax()) {
+        $path = $request->getPathInfo();
+        if ($this->tweakwiseConfig->isPersonalMerchandisingActive() && ($request->isAjax() || $path === '/tweakwise/ajax/navigation/')) {
             $profileKey = $this->cookieManager->getCookie(
                 $this->tweakwiseConfig->getPersonalMerchandisingCookieName(),
                 null
             );
+           
             if ($profileKey) {
                 $navigationRequest->setProfileKey($profileKey);
             }

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -109,15 +109,17 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'ajaxEndpoint' => $this->getAjaxEndPoint(),
                 'filterSelector' => '#layered-filter-block',
                 'productListSelector' => '.products.wrapper',
-                'toolbarSelector' => '.toolbar.toolbar-products'
+                'toolbarSelector' => '.toolbar.toolbar-products',
+                'ajaxCache' => true,
             ],
         ];
         if ($this->config->isPersonalMerchandisingActive()) {
             $pmCookieName = $this->config->getPersonalMerchandisingCookieName();
             if ($pmCookieName) {
+                $path = $this->request->getPathInfo();
                 $navigationFormConfig['tweakwisePMPageReload'] = [
                     'cookieName' => $pmCookieName,
-                    'reloadList' => !$this->request->isAjax(),
+                    'reloadList' => (!$this->request->isAjax() && $path !== '/tweakwise/ajax/navigation/'),
                 ];
                 $navigationFormConfig['tweakwiseNavigationForm']['ajaxCache'] = false;
             }


### PR DESCRIPTION
Fixes bug in  with personal merchandasing in hyva theme. The fetch requests are not seen as ajax requests, and thats why the personal merchandising keeps reloading