### PR TITLE
Bugfix show parent category

### DIFF
--- a/Model/Client/Type/SuggestionType/SuggestionTypeCategory.php
+++ b/Model/Client/Type/SuggestionType/SuggestionTypeCategory.php
@@ -70,7 +70,7 @@ class SuggestionTypeCategory extends SuggestionTypeAbstract
         $parentCategory = $this->getParentCategory();
 
         if ($this->config->showAutocompleteParentCategories() && !empty($parentCategory)) {
-            $categoryName = $parentCategory . '/' . $categoryName;
+            $categoryName = $parentCategory . ' > ' . $categoryName;
         }
 
         return $categoryName ?: $match;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -161,7 +161,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
-                        <field id="show_suggestions">1</field>
+                        <field id="use_suggestions">1</field>
                     </depends>
                 </field>
                 <field id="in_current_category" translate="label,comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
Changes

Setting 'show parent category' was shown under the wrong option.
Changes / to > in autocomplete for parent categories