### PR TITLE
Fix float and 0 prices

### DIFF
--- a/Model/Autocomplete/DataProvider/ProductItem.php
+++ b/Model/Autocomplete/DataProvider/ProductItem.php
@@ -84,7 +84,10 @@ class ProductItem implements ItemInterface
         $price = (float) $priceInfo->getPrice('regular_price')->getValue();
 
         if ($productType == Grouped::TYPE_CODE || $productType == Type::TYPE_BUNDLE) {
-            $price = (float) $product->getData('tweakwise_price');
+            $tweakwisePrice = (float)$product->getData('tweakwise_price');
+            if ($price < $tweakwisePrice) {
+                $price = $tweakwisePrice;
+            }
         }
 
         return [

--- a/Model/Client/Type/ItemType.php
+++ b/Model/Client/Type/ItemType.php
@@ -63,7 +63,7 @@ class ItemType extends Type
      */
     public function getPrice()
     {
-        return (int) $this->getDataValue('price');
+        return (float) $this->getDataValue('price');
     }
 
     /**


### PR DESCRIPTION
Fixes 2 bugs with the prices in the autocomplete for bundled/grouped products

- The price was rounded down by casting the price to an int instead of an float.
- When the tweakwise price is 0, this should not be used as the price of the product. Only use tweakwise price as fallback, when the price is 0 or lower then the tweakwise price.