### PR TITLE
Rename recommendations

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -37,6 +37,8 @@ class Config
     public const ATTRIBUTE_UPSELL_GROUP_CODE = 'tweakwise_upsell_group_code';
     public const ATTRIBUTE_CROSSSELL_TEMPLATE = 'tweakwise_crosssell_template';
     public const ATTRIBUTE_CROSSSELL_GROUP_CODE = 'tweakwise_crosssell_group_code';
+    public const ATTRIBUTE_SHOPPINGCART_CROSSSELL_TEMPLATE = 'tweakwise_shoppingcart_crosssell_template';
+    public const ATTRIBUTE_SHOPPINGCART_CROSSSELL_GROUP_CODE = 'tweakwise_shoppingcart_crosssell_group_code';
     public const ATTRIBUTE_FILTER_WHITELIST = 'tweakwise_filter_whitelist';
     public const ATTRIBUTE_FILTER_VALUES_WHITELIST = 'tweakwise_filter_values_whitelist';
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ This means that the user is greeted by a loader. The product list is reloaded if
 When the product list is loaded in such a manner the result will not be cacheable. This has consequences for server load keep this in mind.
     
 #### Recommendations
-1) Crosssell enabled: Replace magento native related products with tweakwise crosssell & upsell recommendations. Terminology is confusing since this is relevant for magento related products and not for magento crosssell products
-2) Default crosssell template: Which tweakwise recommendation template to use for related products. Only relevant when crosssell is enabled
+1) Related products enabled: Replace magento native related products with tweakwise crosssell & upsell recommendations. Terminology is confusing since this is relevant for magento related products and not for magento crosssell products
+2) Default related products template: Which tweakwise recommendation template to use for related products. Only relevant when crosssell is enabled
     This can also be configured on a product and on a category. The template used is determined as follows: first check product for a configured template if not then check the product category for a template. If the category does not have a template configured then use the default. 
-3) Default crosssell group code: Only visible when Default crosssell template has value '- Group Code -'. Use this to specify the group of recommendations
+3) Default related group code: Only visible when Default crosssell template has value '- Group Code -'. Use this to specify the group of recommendations
 4) Upsell Enabled: Replace magento native upsell results with tweakwise crosssell & upsell recommendations.
 5) Default upsell template: Which template recommendation template to use for upsell products. Only relevant when upsell is enabled.
     This can also be configured on a product and on a category. The template used is determined as follows: first check product for a configured template if not then check the product category for a template. If the category does not have a template configured then use the default.
@@ -92,8 +92,8 @@ When the product list is loaded in such a manner the result will not be cacheabl
 8) Default Featured product template: The default template to use when rendering featured products.
     The template can also be set per category and falls back to this setting if not found on the category. The templates that can be selected correspond with the templates under 'recomendations->featured products' in tweakwise.
 9) Show Cross-sell items in the shoppingcart. Enables tweakwise cross-sell items in the shoppingcart. Magento shoppingcart crossell items should also be enabled under 'Stores->configuration->sales->checkout->Show Cross-sell items in the Shopping Cart'
-10) Default shoppingcart crosssell template. Which tweakwise recommendation template to use for shoppingcart crossell items. Only relevant when shoppingcart crosssell is enabled
-11) Default shoppingcart crosssell group code: Only visible when Default shoppincart crosssell template has value '- Group Code -'. Use this to specify the group of recommendations
+10) Default crosssell template. Which tweakwise recommendation template to use for shoppingcart crossell items. Only relevant when shoppingcart crosssell is enabled
+11) Default crosssell group code: Only visible when Default shoppincart crosssell template has value '- Group Code -'. Use this to specify the group of recommendations
     
 ## Support
 For in depth support regarding configuration and all options tweakwise has to offer use the following links.

--- a/Setup/Patch/Data/AddRecommendationCategoryFieldsPatch.php
+++ b/Setup/Patch/Data/AddRecommendationCategoryFieldsPatch.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tweakwise\Magento2Tweakwise\Setup\Patch\Data;
+
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product;
+use Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface;
+use Magento\Eav\Setup\EavSetup;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Tweakwise\Magento2Tweakwise\Model\Config;
+use Magento\Eav\Setup\EavSetupFactory;
+
+/**
+ * Patch is mechanism, that allows to do atomic upgrade data changes.
+ */
+class AddRecommendationCategoryFieldsPatch implements DataPatchInterface
+{
+	/**
+	 * @var ModuleDataSetupInterface
+	 */
+	private ModuleDataSetupInterface $moduleDataSetup;
+
+	/**
+	 * @param ModuleDataSetupInterface $moduleDataSetup
+	 */
+	public function __construct(
+		ModuleDataSetupInterface $moduleDataSetup,
+        EavSetupFactory $eavSetupFactory
+	)
+	{
+        $this->eavSetupFactory = $eavSetupFactory;
+		$this->moduleDataSetup = $moduleDataSetup;
+	}
+
+	/**
+	 * Do Upgrade.
+	 *
+	 * @return void
+	 */
+	public function apply()
+	{
+		$this->moduleDataSetup->getConnection()->startSetup();
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
+
+		$this->ensureShoppingcartCrosssellTemplateAttribute($eavSetup);
+
+		$this->moduleDataSetup->getConnection()->endSetup();
+	}
+
+	/**
+	 * Get aliases (previous names) for the patch.
+	 *
+	 * @return string[]
+	 */
+	public function getAliases()
+	{
+		return [];
+	}
+
+	/**
+	 * Get array of patches that have to be executed prior to this.
+	 *
+	 * Example of implementation:
+	 *
+	 * [
+	 *      \Vendor_Name\Module_Name\Setup\Patch\Patch1::class,
+	 *      \Vendor_Name\Module_Name\Setup\Patch\Patch2::class
+	 * ]
+	 *
+	 * @return string[]
+	 */
+	public static function getDependencies()
+	{
+		return [];
+	}
+
+    protected function ensureShoppingcartCrosssellTemplateAttribute(EavSetup $eavSetup)
+    {
+        foreach ([Category::ENTITY, Product::ENTITY] as $entityType) {
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_SHOPPINGCART_CROSSSELL_TEMPLATE, [
+                'type' => 'int',
+                'label' => 'Shoppingcart crosssell template',
+                'input' => 'select',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+                'source' => 'Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product',
+            ]);
+
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_SHOPPINGCART_CROSSSELL_GROUP_CODE, [
+                'type' => 'varchar',
+                'label' => 'Shoppincart crosssell code',
+                'input' => 'text',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+            ]);
+        }
+    }
+
+    protected function ensureCrosssellTemplateAttribute(EavSetup $eavSetup)
+    {
+        foreach ([Category::ENTITY, Product::ENTITY] as $entityType) {
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_CROSSSELL_TEMPLATE, [
+                'type' => 'int',
+                'label' => 'Crosssell template',
+                'input' => 'select',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+                'source' => 'Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product',
+            ]);
+
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_CROSSSELL_GROUP_CODE, [
+                'type' => 'varchar',
+                'label' => 'Crosssell group code',
+                'input' => 'text',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+            ]);
+        }
+    }
+
+    protected function ensureUpsellTemplateAttribute(EavSetup $eavSetup)
+    {
+        foreach ([Category::ENTITY, Product::ENTITY] as $entityType) {
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_UPSELL_TEMPLATE, [
+                'type' => 'int',
+                'label' => 'Upsell template',
+                'input' => 'select',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+                'source' => 'Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product',
+            ]);
+
+            $eavSetup->addAttribute($entityType, Config::ATTRIBUTE_UPSELL_GROUP_CODE, [
+                'type' => 'varchar',
+                'label' => 'Upsell group code',
+                'input' => 'text',
+                'required' => false,
+                'sort_order' => 10,
+                'global' => ScopedAttributeInterface::SCOPE_STORE,
+                'group' => 'Tweakwise',
+            ]);
+        }
+    }
+
+    protected function ensureFeaturedTemplateAttribute(EavSetup $eavSetup)
+    {
+        $eavSetup->addAttribute(Category::ENTITY, Config::ATTRIBUTE_FEATURED_TEMPLATE, [
+            'type' => 'int',
+            'label' => 'Featured products template',
+            'input' => 'select',
+            'required' => false,
+            'sort_order' => 10,
+            'global' => ScopedAttributeInterface::SCOPE_STORE,
+            'group' => 'Tweakwise',
+            'source' => 'Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Featured',
+        ]);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -234,12 +234,12 @@
             <group id="recommendations" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Recommendations</label>
                 <field id="crosssell_enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Crosssell enabled</label>
-                    <comment>Shows crosssell product on all product pages. This overrides the default related products. Can also be enabled per category.</comment>
+                    <label>Related products enabled</label>
+                    <comment>Shows related product on all product pages. This overrides the default related products. Can also be enabled per category.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="crosssell_template" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Default crosssell template</label>
+                    <label>Default related products template</label>
                     <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product\System</source_model>
                     <depends>
                         <field id="crosssell_enabled">1</field>
@@ -285,19 +285,19 @@
                     </depends>
                 </field>
                 <field id="shoppingcart_crosssell_enabled" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Shoppingcart Crosssell enabled</label>
-                    <comment>Shows crosssell product in the shoppingcart. This overrides the default crossell product in the shoppingcart</comment>
+                    <label>Crosssell enabled</label>
+                    <comment>Shows crosssell product in the shoppingcart. This overrides the default crossell products in the shoppingcart</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="shoppingcart_crosssell_template" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Default shoppingcart crosssell template</label>
+                    <label>Default crosssell template</label>
                     <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product\System</source_model>
                     <depends>
                         <field id="shoppingcart_crosssell_enabled">1</field>
                     </depends>
                 </field>
                 <field id="shoppingcart_crosssell_group_code" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Default shoppingcart crosssell group code</label>
+                    <label>Default crosssell group code</label>
                     <depends>
                         <field id="shoppingcart_crosssell_enabled">1</field>
                         <field id="shoppingcart_crosssell_template">-1</field>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -28,6 +28,12 @@
     <type name="Magento\Checkout\Block\Cart\Crosssell">
         <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Block\Cart\Crosssell\Plugin" />
     </type>
+    <type name="Magento\Catalog\Block\Product\ProductList\Related">
+        <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Block\Catalog\Product\ProductList\Related\Plugin" sortOrder="0" />
+    </type>
+    <type name="Magento\Catalog\Block\Product\ProductList\Upsell">
+        <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Block\Catalog\Product\ProductList\Upsell\Plugin" sortOrder="0" />
+    </type>
     <type name="Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\FilterList\Plugin">
         <arguments>
             <argument name="tweakwiseFilterList" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\FilterList\Tweakwise\Proxy</argument>
@@ -60,9 +66,6 @@
         <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Block\Checkout\Cart\Crosssell\Plugin" sortOrder="0" />
     </type>
     <!-- End of Commerce only-->
-    <type name="Magento\Catalog\Block\Product\ProductList\Related">
-        <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Block\Catalog\Product\ProductList\Related\Plugin" sortOrder="0" />
-    </type>
     <type name="Magento\Swatches\Helper\Data">
         <plugin name="tweakwise-magento2tweakwise" type="Tweakwise\Magento2Tweakwise\Model\Swatches\Plugin" sortOrder="0" />
     </type>

--- a/view/adminhtml/ui_component/catalogstaging_category_update_form.xml
+++ b/view/adminhtml/ui_component/catalogstaging_category_update_form.xml
@@ -31,7 +31,7 @@
                 <item name="options" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product</item>
                 <item name="config" xsi:type="array">
                     <item name="formElement" xsi:type="string">select</item>
-                    <item name="label" xsi:type="string" translate="true">Product crosssell template</item>
+                    <item name="label" xsi:type="string" translate="true">Related products template</item>
                     <item name="sortOrder" xsi:type="number">20</item>
                 </item>
             </argument>
@@ -40,7 +40,7 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="formElement" xsi:type="string">input</item>
-                    <item name="label" xsi:type="string" translate="true">Product crosssell group code</item>
+                    <item name="label" xsi:type="string" translate="true">Related products group code</item>
                     <item name="comment" xsi:type="string" translate="true">Only used when template "- Group code -" is selected.</item>
                     <item name="sortOrder" xsi:type="number">21</item>
                 </item>

--- a/view/adminhtml/ui_component/category_form.xml
+++ b/view/adminhtml/ui_component/category_form.xml
@@ -31,7 +31,7 @@
                 <item name="options" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption\Product</item>
                 <item name="config" xsi:type="array">
                     <item name="formElement" xsi:type="string">select</item>
-                    <item name="label" xsi:type="string" translate="true">Product crosssell template</item>
+                    <item name="label" xsi:type="string" translate="true">Related products template</item>
                     <item name="sortOrder" xsi:type="number">20</item>
                 </item>
             </argument>
@@ -40,7 +40,7 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="formElement" xsi:type="string">input</item>
-                    <item name="label" xsi:type="string" translate="true">Product crosssell group code</item>
+                    <item name="label" xsi:type="string" translate="true">Related products group code</item>
                     <item name="comment" xsi:type="string" translate="true">Only used when template "- Group code -" is selected.</item>
                     <item name="sortOrder" xsi:type="number">21</item>
                 </item>


### PR DESCRIPTION
Rename recommendation so that the name is the same as magento

crosssell -> related products

Also fixed an bug with upsell not working