### PR TITLE
Removed BR as accept-encoding option

### DIFF
--- a/Model/Client.php
+++ b/Model/Client.php
@@ -87,7 +87,7 @@ class Client
                 RequestOptions::TIMEOUT => self::REQUEST_TIMEOUT,
                 RequestOptions::HEADERS => [
                     'user-agent' => $this->config->getUserAgentString(),
-                    'Accept-Encoding' => 'gzip, deflate, br'
+                    'Accept-Encoding' => 'gzip, deflate'
                 ]
             ];
             $this->client = new HttpClient($options);


### PR DESCRIPTION
After applying this change with a patch on some of our shops, we've seen erratic behavior where sometimes categories couldn't load and got an error page for a number of minutes and categories are not accessible. The Xml internal error is non readable and can't be parsed. Removing BR seems to fix the issue.

Could it be that certain nodes from Tweakwise are only giving back br and perhaps some versions of curl don't support it, etc..? Just for safety, I suggest we remove Brotly for now. Perhaps some added control through system configuration would in the end be better, with gzip and deflate as default.