### PR TITLE
Bugfix category url with slash

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -551,7 +551,18 @@ class PathSlugStrategy implements
          This is needed because the categoryUrlPath contains the store code in some cases and the directUrl as well.
          These two are the only unique parts in this situation and so need to be removed.
          */
-        return implode('/', array_unique(explode('/', $url)));
+
+        $explode = explode('/', $url);
+        $lastpart = array_last($explode);
+
+        $url = implode('/', array_unique($explode));
+
+        if ($lastpart === "") {
+            //last part of the url was an slash, and needs te be re-added
+            $url .= '/';
+        }
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
When category url suffix is set to slash, the slash is removed by the array unique function. This fix re-adds the slash at the end of the category link if the last part was an slash