### PR TITLE
Bugfix search enabled

### DIFF
--- a/Block/Navigation/FilterRenderer/Plugin.php
+++ b/Block/Navigation/FilterRenderer/Plugin.php
@@ -93,7 +93,10 @@ class Plugin
         }
 
         if (!$this->config->isLayeredEnabled()) {
-            return $proceed($filter);
+            $request = $subject->getRequest();
+            if (!$this->config->isSearchEnabled() || (($request->getModuleName() !== 'catalogsearch') && (stripos($request->getParam('__tw_original_url'), 'catalogsearch')) === false)) {
+                return $proceed($filter);
+            }
         }
 
         $facet = $filter->getFacet();

--- a/Model/Catalog/Layer/FilterList/Plugin.php
+++ b/Model/Catalog/Layer/FilterList/Plugin.php
@@ -56,7 +56,9 @@ class Plugin
     public function aroundGetFilters(FilterList $subject, Closure $proceed, Layer $layer)
     {
         if (!$this->config->isLayeredEnabled()) {
-            return $proceed($layer);
+            if (!$this->config->isSearchEnabled() || !($layer instanceof Layer\Search)) {
+                return $proceed($layer);
+            }
         }
 
         try {

--- a/Model/Catalog/Layer/ItemCollectionProvider.php
+++ b/Model/Catalog/Layer/ItemCollectionProvider.php
@@ -10,6 +10,7 @@ namespace Tweakwise\Magento2Tweakwise\Model\Catalog\Layer;
 
 use Tweakwise\Magento2Tweakwise\Exception\TweakwiseException;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Product\CollectionFactory;
+use Tweakwise\Magento2Tweakwise\Model\Client\Request\ProductSearchRequest;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Logger;
 use Magento\Catalog\Model\Category;
@@ -71,7 +72,9 @@ class ItemCollectionProvider implements ItemCollectionProviderInterface
     public function getCollection(Category $category)
     {
         if (!$this->config->isLayeredEnabled()) {
-            return $this->originalProvider->getCollection($category);
+            if (!$this->config->isSearchEnabled() || !($this->navigationContext->getRequest() instanceof ProductSearchRequest)) {
+                return $this->originalProvider->getCollection($category);
+            }
         }
 
         try {


### PR DESCRIPTION
With tweakwise search enabled and layered navigation disabled, the searchresults from tweakwise are not shown. This pull request fixes that.