### PR TITLE
Fixed "Uncaught TypeError: $(...).slider is not a function"

### DIFF
--- a/view/frontend/web/js/navigation-slider.js
+++ b/view/frontend/web/js/navigation-slider.js
@@ -7,7 +7,7 @@
 
 define([
     'jquery',
-    'jquery-ui-modules/slider',
+    'jquery/ui-modules/widgets/slider',
     'jQueryTouchPunch',
     'domReady!'
 ], function ($) {


### PR DESCRIPTION
This fixes the "Uncaught TypeError: $(...).slider is not a function" error when the slider function is called as of magento 2.4.4.