### PR TITLE
Hide categorie in url

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -153,6 +153,7 @@
                 <item name="ajax_type" xsi:type="string">__tw_ajax_type</item>
                 <item name="ajax_cache" xsi:type="string">_</item>
                 <item name="hash" xsi:type="string">__tw_hash</item>
+                <item name="categorie" xsi:type="string">categorie</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Catalogsearch URLs like /catalogsearch/result/?q=yoga are redirected to catalogsearch/result/index?q=yoga&category=2

This should not be happening. The categorie field should not be shown in the url.

This pull request fixes that.
