### PR TITLE
Bugfix category rewrite

### DIFF
--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -113,7 +113,7 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
      */
     public function getOriginalUrl()
     {
-        return str_replace($this->url->getBaseUrl(), '', $this->getCategory()->getUrl());
+        return str_replace($this->url->getBaseUrl(), '', $this->url->getCurrentUrl());
     }
 
     /**


### PR DESCRIPTION
When you create an url rewrite for an category without an redirect the url gets changed to te original category url.

For example if you have an category url /swimwear and for your shop in another language you create an rewrite (without redirect) for the category with /zwemkleding. 

If you go to /zwemkleding you should stay on the url (because there is no redirect). But it redirects to /swimwear (with ajax navigation enabled)

This pull request fixes that