### PR TITLE
Fix category url if url is rewrite

### DIFF
--- a/Model/Catalog/Layer/Url.php
+++ b/Model/Catalog/Layer/Url.php
@@ -111,7 +111,7 @@ class Url
     /**
      * @return CategoryUrlInterface
      */
-    protected function getCategoryUrlStrategy()
+    public function getCategoryUrlStrategy()
     {
         if (!$this->categoryUrlStrategy) {
             $this->categoryUrlStrategy = $this->urlStrategyFactory

--- a/Model/Catalog/Layer/Url.php
+++ b/Model/Catalog/Layer/Url.php
@@ -111,7 +111,7 @@ class Url
     /**
      * @return CategoryUrlInterface
      */
-    public function getCategoryUrlStrategy()
+    protected function getCategoryUrlStrategy()
     {
         if (!$this->categoryUrlStrategy) {
             $this->categoryUrlStrategy = $this->urlStrategyFactory

--- a/Model/Catalog/Layer/Url.php
+++ b/Model/Catalog/Layer/Url.php
@@ -86,7 +86,7 @@ class Url
     /**
      * @return UrlInterface
      */
-    protected function getUrlStrategy()
+    public function getUrlStrategy()
     {
         if (!$this->urlStrategy) {
             $this->urlStrategy = $this->urlStrategyFactory->create();

--- a/Model/Catalog/Layer/Url/Strategy/NullStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/NullStrategy.php
@@ -102,4 +102,11 @@ class NullStrategy implements RouteMatchingInterface, UrlInterface, FilterApplie
     {
         return '';
     }
+    /**
+     * @return string
+     */
+    public function getOriginalUrl(MagentoHttpRequest $request) : string
+    {
+        return '';
+    }
 }

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -330,7 +330,7 @@ class PathSlugStrategy implements
      */
     protected function getCurrentUrl(MagentoHttpRequest $request): string
     {
-        $url = $request->getRequestUri();
+        $url = $request->getOriginalPathInfo();
 
         return str_replace($this->magentoUrl->getBaseUrl(), '', $url);
     }

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -312,7 +312,7 @@ class PathSlugStrategy implements
             );
         }
 
-        return $this->getCurrentUrl();
+        return $this->getCurrentUrl($request);
     }
 
     /**
@@ -326,12 +326,17 @@ class PathSlugStrategy implements
     /**
      * @return string
      */
-    protected function getCurrentUrl(): string
+    protected function getCurrentUrl(MagentoHttpRequest $request): string
     {
-        $params['_current'] = true;
-        $params['_use_rewrite'] = true;
-        $params['_escape'] = false;
-        return $this->magentoUrl->getUrl('*/*/*', $params);
+        $url = $this->buildFilterUrl($request);
+
+        //remove query string
+        $pos = stripos($url, '?');
+        if (!empty($pos)) {
+            $url = substr($url, 0, $pos);
+        }
+
+        return str_replace($this->url->getBaseUrl(), '', $url);
     }
 
     /**

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -328,15 +328,8 @@ class PathSlugStrategy implements
      */
     protected function getCurrentUrl(MagentoHttpRequest $request): string
     {
-        $url = $this->buildFilterUrl($request);
-
-        //remove query string
-        $pos = stripos($url, '?');
-        if (!empty($pos)) {
-            $url = substr($url, 0, $pos);
-        }
-
-        return str_replace($this->url->getBaseUrl(), '', $url);
+        $url = $request->getRequestUri();
+        return str_replace($this->magentoUrl->getBaseUrl(), '', $url);
     }
 
     /**

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -306,10 +306,12 @@ class PathSlugStrategy implements
                 $query['product_list_mode'] = $mode;
             }
 
-            return filter_var(
+            $url = filter_var(
                 $this->magentoUrl->getDirectUrl($twOriginalUrl, ['_query' => $query]),
                 FILTER_SANITIZE_URL
             );
+
+            return str_replace($this->magentoUrl->getBaseUrl(), '', $url);
         }
 
         return $this->getCurrentUrl($request);
@@ -329,6 +331,7 @@ class PathSlugStrategy implements
     protected function getCurrentUrl(MagentoHttpRequest $request): string
     {
         $url = $request->getRequestUri();
+
         return str_replace($this->magentoUrl->getBaseUrl(), '', $url);
     }
 

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -135,26 +135,15 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
      */
     protected function getCurrentQueryUrl(MagentoHttpRequest $request, array $query)
     {
-        $params['_current'] = true;
-        $params['_use_rewrite'] = true;
         $params['_query'] = $query;
-        $params['_escape'] = false;
 
         if ($originalUrl = $request->getQuery('__tw_original_url')) {
-            $urlArray = explode('/', $originalUrl);
-            $newOriginalUrl = '';
-            foreach ($urlArray as $url) {
-                $newOriginalUrl .= '/' . filter_var($url, FILTER_SANITIZE_ENCODED);
-            }
 
-            //check if string should start with an / to prevent double slashes later
-            if (strpos(mb_substr($originalUrl, 0, 1), '/', ) === false) {
-                $newOriginalUrl = mb_substr($newOriginalUrl, 1);
-            }
+            $newOriginalUrl = $this->url->getDirectUrl($this->getOriginalUrl($request), $params);
 
-            return $this->url->getDirectUrl($newOriginalUrl, $params);
+            return str_replace($this->url->getBaseUrl(), '', $newOriginalUrl);
         }
-        return $this->url->getUrl('*/*/*', $params);
+        return $this->url->getDirectUrl($this->getOriginalUrl($request), $params);
     }
 
     /**
@@ -478,7 +467,30 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
      */
     public function getOriginalUrl(MagentoHttpRequest $request) : string
     {
-        $url = $this->layerUrl->getUrlStrategy()->getOriginalUrl($request);
+        if ($originalUrl = $request->getQuery('__tw_original_url')) {
+            $urlArray = explode('/', $originalUrl);
+            $newOriginalUrl = '';
+            foreach ($urlArray as $url) {
+                $newOriginalUrl .= '/' . filter_var($url, FILTER_SANITIZE_ENCODED);
+            }
+
+            //check if string should start with an / to prevent double slashes later
+            if (mb_stripos($originalUrl, '/') === 0) {
+                $newOriginalUrl = mb_substr($newOriginalUrl, 1);
+            }
+
+            $newOriginalUrl = $this->url->getDirectUrl($newOriginalUrl);
+
+            return str_replace($this->url->getBaseUrl(), '', $newOriginalUrl);
+        }
+
+        return $this->getCurrentUrl($request);
+    }
+
+    private function getCurrentUrl(MagentoHttpRequest $request) : string
+    {
+        $url = $request->getRequestUri();
+
         return str_replace($this->url->getBaseUrl(), '', $url);
     }
 }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -489,7 +489,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
 
     private function getCurrentUrl(MagentoHttpRequest $request) : string
     {
-        $url = $request->getRequestUri();
+        $url = $request->getOriginalPathInfo();
 
         return str_replace($this->url->getBaseUrl(), '', $url);
     }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -21,6 +21,7 @@ use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\App\Request\Http as MagentoHttpRequest;
 use Magento\Framework\Stdlib\CookieManagerInterface;
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url;
 
 class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, CategoryUrlInterface
 {
@@ -78,8 +79,15 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
      */
     protected $tweakwiseConfig;
 
-
+    /**
+     * @var array
+     */
     private $queryUrlCache = [];
+
+    /**
+     * @var Url
+     */
+    protected $layerUrl;
 
     /**
      * Magento constructor.
@@ -93,12 +101,14 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
         UrlModel $url,
         StrategyHelper $strategyHelper,
         CookieManagerInterface $cookieManager,
-        TweakwiseConfig $config
+        TweakwiseConfig $config,
+        Url $layerUrl
     ) {
         $this->url = $url;
         $this->strategyHelper = $strategyHelper;
         $this->cookieManager = $cookieManager;
         $this->tweakwiseConfig = $config;
+        $this->layerUrl = $layerUrl;
     }
 
     /**
@@ -461,5 +471,14 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
     public function isAllowed(): bool
     {
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginalUrl(MagentoHttpRequest $request) : string
+    {
+        $url = $this->layerUrl->getUrlStrategy()->getOriginalUrl($request);
+        return str_replace($this->url->getBaseUrl(), '', $url);
     }
 }

--- a/Model/Catalog/Layer/Url/UrlInterface.php
+++ b/Model/Catalog/Layer/Url/UrlInterface.php
@@ -65,4 +65,12 @@ interface UrlInterface
      * @return boolean
      */
     public function isAllowed(): bool;
+
+    /**
+     * Determine the original url
+     *
+     * @param MagentoHttpRequest $request
+     * @return string
+     */
+    public function getOriginalUrl(MagentoHttpRequest $request): string;
 }

--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -11,6 +11,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class CategoryInputProvider implements FilterFormInputProviderInterface
@@ -63,6 +64,11 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
     protected $request;
 
     /**
+     * @var Url
+     */
+    protected $urlStrategy;
+
+    /**
      * CategoryParameterProvider constructor.
      * @param UrlInterface $url
      * @param Registry $registry
@@ -81,7 +87,8 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         CategoryInterfaceFactory $categoryFactory,
         ToolbarInputProvider $toolbarInputProvider,
         HashInputProvider $hashInputProvider,
-        MagentoHttpRequest $request
+        MagentoHttpRequest $request,
+        Url $urlStrategy
     ) {
         $this->url = $url;
         $this->registry = $registry;
@@ -92,6 +99,7 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         $this->toolbarInputProvider = $toolbarInputProvider;
         $this->hashInputProvider = $hashInputProvider;
         $this->request = $request;
+        $this->urlStrategy = $urlStrategy;
     }
 
     /**
@@ -121,11 +129,12 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
      */
     public function getOriginalUrl()
     {
-        $originalUrl = $this->request->get('__tw_original_url');
-        $url = $this->url->getDirectUrl($this->url->getCurrentUrl());
+        $url = $this->urlStrategy->getCategoryUrlStrategy()->buildFilterUrl($this->request);
 
-        if (!empty($originalUrl)) {
-            $url = $originalUrl;
+        //remove query string
+        $pos = stripos($url, '?');
+        if (!empty($pos)) {
+            $url = substr($url, 0, $pos);
         }
 
         return str_replace($this->url->getBaseUrl(), '', $url);

--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -6,12 +6,10 @@ use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterfaceFactory;
 use Magento\Catalog\Model\Category;
-use Magento\Framework\App\Request\Http as MagentoHttpRequest;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class CategoryInputProvider implements FilterFormInputProviderInterface
@@ -59,16 +57,6 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
     protected $hashInputProvider;
 
     /**
-     * @var MagentoHttpRequest
-     */
-    protected $request;
-
-    /**
-     * @var Url
-     */
-    protected $urlStrategy;
-
-    /**
      * CategoryParameterProvider constructor.
      * @param UrlInterface $url
      * @param Registry $registry
@@ -86,9 +74,7 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         CategoryRepositoryInterface $categoryRepository,
         CategoryInterfaceFactory $categoryFactory,
         ToolbarInputProvider $toolbarInputProvider,
-        HashInputProvider $hashInputProvider,
-        MagentoHttpRequest $request,
-        Url $urlStrategy
+        HashInputProvider $hashInputProvider
     ) {
         $this->url = $url;
         $this->registry = $registry;
@@ -98,8 +84,6 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         $this->categoryFactory = $categoryFactory;
         $this->toolbarInputProvider = $toolbarInputProvider;
         $this->hashInputProvider = $hashInputProvider;
-        $this->request = $request;
-        $this->urlStrategy = $urlStrategy;
     }
 
     /**
@@ -129,15 +113,7 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
      */
     public function getOriginalUrl()
     {
-        $url = $this->urlStrategy->getCategoryUrlStrategy()->buildFilterUrl($this->request);
-
-        //remove query string
-        $pos = stripos($url, '?');
-        if (!empty($pos)) {
-            $url = substr($url, 0, $pos);
-        }
-
-        return str_replace($this->url->getBaseUrl(), '', $url);
+        return str_replace($this->url->getBaseUrl(), '', $this->getCategory()->getUrl());
     }
 
     /**

--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -6,6 +6,7 @@ use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterfaceFactory;
 use Magento\Catalog\Model\Category;
+use Magento\Framework\App\Request\Http as MagentoHttpRequest;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
@@ -57,6 +58,11 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
     protected $hashInputProvider;
 
     /**
+     * @var MagentoHttpRequest
+     */
+    protected $request;
+
+    /**
      * CategoryParameterProvider constructor.
      * @param UrlInterface $url
      * @param Registry $registry
@@ -74,7 +80,8 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         CategoryRepositoryInterface $categoryRepository,
         CategoryInterfaceFactory $categoryFactory,
         ToolbarInputProvider $toolbarInputProvider,
-        HashInputProvider $hashInputProvider
+        HashInputProvider $hashInputProvider,
+        MagentoHttpRequest $request
     ) {
         $this->url = $url;
         $this->registry = $registry;
@@ -84,6 +91,7 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         $this->categoryFactory = $categoryFactory;
         $this->toolbarInputProvider = $toolbarInputProvider;
         $this->hashInputProvider = $hashInputProvider;
+        $this->request = $request;
     }
 
     /**
@@ -113,7 +121,14 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
      */
     public function getOriginalUrl()
     {
-        return str_replace($this->url->getBaseUrl(), '', $this->getCategory()->getUrl());
+        $originalUrl = $this->request->get('__tw_original_url');
+        $url = $this->url->getDirectUrl($this->url->getCurrentUrl());
+
+        if (!empty($originalUrl)) {
+            $url = $originalUrl;
+        }
+
+        return str_replace($this->url->getBaseUrl(), '', $url);
     }
 
     /**

--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -11,6 +11,9 @@ use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Config;
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url;
+use Magento\Framework\App\Request\Http as MagentoHttpRequest;
+
 
 class CategoryInputProvider implements FilterFormInputProviderInterface
 {
@@ -57,6 +60,16 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
     protected $hashInputProvider;
 
     /**
+     * @var Url
+     */
+    protected $layerUrl;
+
+    /**
+     * @var MagentoHttpRequest
+     */
+    protected $request;
+
+    /**
      * CategoryParameterProvider constructor.
      * @param UrlInterface $url
      * @param Registry $registry
@@ -74,7 +87,9 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         CategoryRepositoryInterface $categoryRepository,
         CategoryInterfaceFactory $categoryFactory,
         ToolbarInputProvider $toolbarInputProvider,
-        HashInputProvider $hashInputProvider
+        HashInputProvider $hashInputProvider,
+        Url $layerUrl,
+        MagentoHttpRequest $request
     ) {
         $this->url = $url;
         $this->registry = $registry;
@@ -84,6 +99,8 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
         $this->categoryFactory = $categoryFactory;
         $this->toolbarInputProvider = $toolbarInputProvider;
         $this->hashInputProvider = $hashInputProvider;
+        $this->layerUrl = $layerUrl;
+        $this->request = $request;
     }
 
     /**
@@ -107,13 +124,11 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
     }
 
     /**
-     * Public because of plugin options
-     *
      * @return string
      */
-    public function getOriginalUrl()
+    public function getOriginalUrl() : string
     {
-        return str_replace($this->url->getBaseUrl(), '', $this->getCategory()->getUrl());
+        return $this->layerUrl->getUrlStrategy()->getOriginalUrl($this->request);
     }
 
     /**


### PR DESCRIPTION
When you create an url rewrite for an category without an redirect the url gets changed to te original category url.

For example if you have an category url /swimwear and for your shop in another language you create an rewrite (without redirect) for the category with /zwemkleding.

If you go to /zwemkleding you should stay on the url (because there is no redirect). But it redirects to /swimwear (with ajax navigation enabled)

This pull request fixes that