### PR TITLE
Add fallback for categories

### DIFF
--- a/Block/Catalog/Product/ProductList/Featured.php
+++ b/Block/Catalog/Product/ProductList/Featured.php
@@ -166,6 +166,9 @@ class Featured extends ListProduct
         $category = $this->_coreRegistry->registry('current_category');
         if ($category instanceof Category) {
             $templateId = $this->templateFinder->forCategory($category, Config::RECOMMENDATION_TYPE_FEATURED);
+            if (!$templateId) {
+                $templateId = $this->config->getRecommendationsTemplate(Config::RECOMMENDATION_TYPE_FEATURED);
+            }
         } else {
             $templateId = $this->config->getRecommendationsTemplate(Config::RECOMMENDATION_TYPE_FEATURED);
         }

--- a/Model/Config/TemplateFinder.php
+++ b/Model/Config/TemplateFinder.php
@@ -2,10 +2,12 @@
 
 namespace Tweakwise\Magento2Tweakwise\Model\Config;
 
+use Magento\Framework\Registry;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 use Tweakwise\Magento2Tweakwise\Model\Config\Source\RecommendationOption;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\CategoryRepository;
 
 class TemplateFinder
 {
@@ -15,12 +17,24 @@ class TemplateFinder
     protected $config;
 
     /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @var CategoryRepository
+     */
+    protected $categoryRepository;
+
+    /**
      * TemplateFinder constructor.
      * @param Config $config
      */
-    public function __construct(Config $config)
+    public function __construct(Config $config, Registry $registry, CategoryRepository $categoryRepository)
     {
         $this->config = $config;
+        $this->registry = $registry;
+        $this->categoryRepository = $categoryRepository;
     }
 
     /**
@@ -33,6 +47,7 @@ class TemplateFinder
         $attribute = $this->getAttribute($type);
         $templateId = (int) $product->getData($attribute);
 
+        //first try product template
         if ($templateId === RecommendationOption::OPTION_CODE) {
             $groupAttribute = $this->getGroupCodeAttribute($type);
             return (string) $product->getData($groupAttribute);
@@ -42,9 +57,37 @@ class TemplateFinder
             return $templateId;
         }
 
+        //try template from the most recent category
+        $category = $this->registry->registry('current_category');
+
+        if ($category) {
+            $templateId = $this->forCategory($category, $type);
+
+            if ($templateId) {
+                return $templateId;
+            }
+        }
+
+        //try default product category
         $category = $product->getCategory();
         if ($category) {
-            return $this->forCategory($category, $type);
+            $templateId = $this->forCategory($category, $type);
+        }
+
+        if ($templateId) {
+            return $templateId;
+        }
+
+        //try template for other categories of the product
+        $categoryIds = $product->getCategoryIds();
+
+        foreach($categoryIds as $categoryId) {
+            $category = $this->categoryRepository->get($categoryId);
+            $templateId = $this->forCategory($category, $type);
+
+            if ($templateId) {
+                return $templateId;
+            }
         }
 
         $defaultTemplateId = $this->config->getRecommendationsTemplate($type);
@@ -80,13 +123,7 @@ class TemplateFinder
             return $this->forCategory($parent, $type);
         }
 
-        $defaultTemplateId = $this->config->getRecommendationsTemplate($type);
-
-        if ($defaultTemplateId === RecommendationOption::OPTION_CODE) {
-            return $this->config->getRecommendationsGroupCode($type);
-        }
-
-        return $defaultTemplateId;
+        return null;
     }
 
     /**


### PR DESCRIPTION
This adds an fallback when an product belongs to multiple categories. First the current category is checked (if the current category exists). Then the default category for the product. And then all other categories for this product. If no templates are found, the default template is used.

The first recommendation template found is used.