### PR TITLE
Fix pagination/sorting url

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -479,7 +479,24 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
                 $newOriginalUrl = mb_substr($newOriginalUrl, 1);
             }
 
-            $newOriginalUrl = $this->url->getDirectUrl($newOriginalUrl);
+            // This seems ugly, perhaps there is another way?
+            $query = [];
+            // Add page and sort
+            $sort = $request->getParam('product_list_order');
+            $limit = $request->getParam('product_list_limit');
+            $mode = $request->getParam('product_list_mode');
+
+            if ($sort) {
+                $query['product_list_order'] = $sort;
+            }
+            if ($limit) {
+                $query['product_list_limit'] = $limit;
+            }
+            if ($mode) {
+                $query['product_list_mode'] = $mode;
+            }
+
+            $newOriginalUrl = $this->url->getDirectUrl($newOriginalUrl, ['_query' => $query]);
 
             return str_replace($this->url->getBaseUrl(), '', $newOriginalUrl);
         }

--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -112,10 +112,14 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
             return [];
         }
 
+        $url = $this->getOriginalUrl();
+
+        $url = strtok($url, '?');
+
         $input = [
             '__tw_ajax_type' => self::TYPE,
             '__tw_object_id' => $this->getCategoryId(),
-            '__tw_original_url' => $this->getOriginalUrl(),
+            '__tw_original_url' => $url,
         ];
 
         $input['__tw_hash'] = $this->hashInputProvider->getHash($input);


### PR DESCRIPTION
When url stategy is query parameters, the sorting/pagination is not working properly. The url parameter from pagination url is incorrect after the second/third page.