### PR TITLE
Draft: Add query parameters back after Tweakwise Personal Merchandier Refresh

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,7 +358,8 @@ define([
          * @private
          */
         _updateState: function (response) {
-            window.history.pushState({html: response.html}, '', response.url + window.location.search);
+            const newUrl = this._buildUrlWithQueryString(response);
+            window.history.pushState({html: response.html}, '', newUrl);
         },
 
         /**

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,7 +358,7 @@ define([
          * @private
          */
         _updateState: function (response) {
-            window.history.pushState({html: response.html}, '', response.url);
+            window.history.pushState({html: response.html}, '', response.url + window.location.search);
         },
 
         /**


### PR DESCRIPTION
There is an issue with the refresh the Personal Merchandiser does and query parameters used by marketing teams to track clicks from newsletters/blogs etc.

This reads the query parameters if there were any on the PM refresh (and other unintended refreshes)