### PR TITLE
Merge query parameters back after Tweakwise Personal Merchandier Refresh

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,7 +358,7 @@ define([
          * @private
          */
         _updateState: function (response) {
-            const newUrl = this._buildUrlWithQueryString(response);
+            const newUrl = this._buildUrlWithQueryString(response, true);
             window.history.pushState({html: response.html}, '', newUrl);
         },
 
@@ -375,17 +375,22 @@ define([
          * Merges existed query parameters with the ones get from AJAX response if needed
          *
          * @param response
+         * @param flip
          * @returns string
          * @private
          */
-        _buildUrlWithQueryString: function (response) {
+        _buildUrlWithQueryString: function (response, flip = false) {
             const baseUrl = window.location.origin;
             const resultUrl = new URL(response.url, baseUrl);
             const queryParams = new URLSearchParams(window.location.search ?? '');
             let queryParamsString = queryParams.toString();
 
             if (resultUrl.search) {
-                queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
+                if (flip) {
+                    queryParamsString = this._combineQueryStrings(resultUrl.searchParams, queryParams);
+                } else {
+                    queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
+                }
             }
 
             resultUrl.search = queryParamsString;

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,7 +358,8 @@ define([
          * @private
          */
         _updateState: function (response) {
-            window.history.pushState({html: response.html}, '', response.url);
+            const newUrl = this._buildUrlWithQueryString(response);
+            window.history.pushState({html: response.html}, '', newUrl);
         },
 
         /**

--- a/view/frontend/web/js/pm-page-reload.js
+++ b/view/frontend/web/js/pm-page-reload.js
@@ -1,7 +1,7 @@
 /**
  * Tweakwise (https://www.tweakwise.com/) - All Rights Reserved
  *
- * @copyright Copyright (c) 2017-2022 Tweakwise.com B.V. (https://www.tweakwise.com)
+ * @copyright Copyright (c) 2017-2023 Tweakwise.com B.V. (https://www.tweakwise.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -27,6 +27,11 @@ define([
                 && this.options.cookieName
                 && ($.mage.cookies.get(this.options.cookieName) !== null);
             if (reload) {
+                const urlParams = new URLSearchParams(window.location.search);
+                const pageParam = urlParams.get('p');
+                if (pageParam) {
+                    $(this.element.append('<input type="hidden" name="p" value="'+ pageParam +'" />'))
+                }
                 this.element.trigger('change');
             }
         }

--- a/view/frontend/web/js/pm-page-reload.js
+++ b/view/frontend/web/js/pm-page-reload.js
@@ -30,7 +30,7 @@ define([
                 const urlParams = new URLSearchParams(window.location.search);
                 const pageParam = urlParams.get('p');
                 if (pageParam) {
-                    $(this.element.append('<input type="hidden" name="p" value="'+ pageParam +'" />'))
+                    $(this.element.append('<input type="hidden" name="p" value="'+ parseInt(pageParam) +'" />'))
                 }
                 this.element.trigger('change');
             }


### PR DESCRIPTION
There is an issue with the refresh the Personal Merchandiser does and query parameters used by marketing teams to track clicks from newsletters/blogs etc.

This reads the query parameters if there were any on the PM refresh (and other unintended refreshes)
