### PR TITLE
Fix bug multiple filters

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -135,6 +135,13 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
      */
     protected function getCurrentQueryUrl(MagentoHttpRequest $request, array $query)
     {
+        $selectedFilters = $request->getQuery();
+        foreach ($selectedFilters as $filter => $value) {
+            if (!isset($query[$filter])) {
+                $query[$filter] = $value;
+            }
+        }
+
         $params['_query'] = $query;
         $params['_escape'] = false;
 
@@ -528,6 +535,8 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
             $params['_escape'] = false;
             return $this->url->getUrl('*/*/*', $params);
         }
+
+        $url = ltrim($url, '/');
 
         return str_replace($this->url->getBaseUrl(), '', $url);
     }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -137,7 +137,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
     {
         $selectedFilters = $request->getQuery();
         foreach ($selectedFilters as $filter => $value) {
-            if (!isset($query[$filter])) {
+            if (!array_key_exists($filter, $query)) {
                 $query[$filter] = $value;
             }
         }


### PR DESCRIPTION
Fixes #77

When using query parameter strategy for urls. Selecting multiple different filters (example sisze and color) doesn't work anymore. This pull request fixes that.

This also fixes double // in the url