### PR TITLE
Fixed issue where feed was not accessible when website restrictions apply

### DIFF
--- a/Observer/WebsiteRestrictionObserver.php
+++ b/Observer/WebsiteRestrictionObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tweakwise\Magento2Tweakwise\Observer;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Allow Tweakwise feed to be accessed when website restrctions apply
+ */
+class WebsiteRestrictionObserver implements ObserverInterface
+{
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @param RequestInterface $request
+     */
+    public function __construct(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer): void
+    {
+        if ($this->request->getFullActionName() == 'tweakwise_feed_export') {
+            $result = $observer->getResult();
+            $result->setData('should_proceed', false);
+        }
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -15,4 +15,8 @@
     <event name="view_block_abstract_to_html_before">
         <observer name="tweakwise-magento2tweakwise-navigation-override" instance="Tweakwise\Magento2Tweakwise\Model\Observer\NavigationHtmlOverride" />
     </event>
+
+    <event name="websiterestriction_frontend">
+        <observer name="tweakwise_feed_website_restriction" instance="Tweakwise\Magento2Tweakwise\Observer\WebsiteRestrictionObserver" />
+    </event>
 </config>


### PR DESCRIPTION
**Steps to reproduce**

Enable website restrictions
```
bin/magento config:set  general/restriction/is_active 1
bin/magento config:set  general/restriction/mode 1
```

Try to access the feed (e.g https://domain.com/tweakwise/feed/export/key/abcdefgh/

**Expected result**
Feed is downloaded

**Actual result**
Redirect to either login or cms page (based on settings)

This fix was inspired by the native  Magento_LoginAsCustomerWebsiteRestriction module (part of magento/product-enterprise-edition)

