### PR TITLE
Remove category filter for facets requests

### DIFF
--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -46,7 +46,8 @@ class FacetAttributes extends Action
 
         $categoryId = $this->getRequest()->getParam('category');
         $facetKey = $this->getRequest()->getParam('facetkey');
-        $facetRequest->addCategoryFilter($categoryId);
+        //remove category id for now. It can give the wrong store id for the admin which results in the wrong tncid
+        //$facetRequest->addCategoryFilter($categoryId);
         $facetRequest->addFacetKey($facetKey);
 
         $result = [];

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -45,7 +45,8 @@ class Facets extends Action
         $facetRequest = $this->requestFactory->create();
 
         $categoryId = $this->getRequest()->getParam('category');
-        $facetRequest->addCategoryFilter($categoryId);
+        //remove category id for now. It can give the wrong store id for the admin which results in the wrong tncid
+        //$facetRequest->addCategoryFilter($categoryId);
 
         $response = $this->client->request($facetRequest);
         $result = [];


### PR DESCRIPTION
When using multiple stores. The store id for the facets requests in the admin can get the wrong store id. Which results in the wrong tncid and an empty response.

This removes the category filter. It should result in all facets/values being shown instead of those of the selected category. But it fixes the problem with no results being shown. 