### PR TITLE
Fixes ALP facets for multiple stores

### DIFF
--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -46,8 +46,16 @@ class FacetAttributes extends Action
 
         $categoryId = $this->getRequest()->getParam('category');
         $facetKey = $this->getRequest()->getParam('facetkey');
+        $filtertemplate = (int)$this->getRequest()->getParam('filtertemplate');
         $allStores = $facetRequest->getStores();
-        $facetRequest->addFacetKey($facetKey);
+
+        if (!empty($facetKey)) {
+            $facetRequest->addFacetKey($facetKey);
+        }
+
+        if (!empty($filtertemplate)) {
+            $facetRequest->addParameter('tn_ft', $filtertemplate);
+        }
 
         $result = [];
         foreach ($allStores as $store) {

--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -79,6 +79,8 @@ class FacetAttributes extends Action
             }
         }
 
+        $result[] = ['value' => 'tw_other', 'label' => 'Other (text field)'];
+
         $result = array_unique($result, SORT_REGULAR);
 
         //prevent non sequential array keys. That causes json encode to act diffrently and creates objects instead of arrays

--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -81,6 +81,8 @@ class FacetAttributes extends Action
 
         $result = array_unique($result, SORT_REGULAR);
 
+        //prevent non sequential array keys. That causes json encode to act diffrently and creates objects instead of arrays
+        $result = array_values($result);
 
         $json->setData(['data' => $result]);
         return $json;

--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -46,21 +46,33 @@ class FacetAttributes extends Action
 
         $categoryId = $this->getRequest()->getParam('category');
         $facetKey = $this->getRequest()->getParam('facetkey');
-        //remove category id for now. It can give the wrong store id for the admin which results in the wrong tncid
-        //$facetRequest->addCategoryFilter($categoryId);
+        $allStores = $facetRequest->getStores();
         $facetRequest->addFacetKey($facetKey);
 
         $result = [];
-        try {
-            $response = $this->client->request($facetRequest);
-            foreach ($response->getAttributes() as $attribute) {
-                $result[] = ['value' => $attribute['title'], 'label' => $attribute['title']];
+        foreach ($allStores as $store) {
+            $facetRequest->setStore($store->getId());
+            if (!empty($categoryId)) {
+                $facetRequest->addCategoryFilter($categoryId);
             }
-        } catch (ApiException $e) {
-            if (!$e->getCode() == 404) {
-                throw $e;
+            try {
+                $response = $this->client->request($facetRequest);
+            } catch (ApiException $e) {
+                if (!$e->getCode() == 404) {
+                    throw $e;
+                }
+                continue;
+            }
+
+            if (!empty($response->getAttributes())) {
+                foreach ($response->getAttributes() as $attribute) {
+                    $result[] = ['value' => $attribute['title'], 'label' => $attribute['title']];
+                }
             }
         }
+
+        $result = array_unique($result, SORT_REGULAR);
+
 
         $json->setData(['data' => $result]);
         return $json;

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -41,18 +41,27 @@ class Facets extends Action
 
     public function execute()
     {
+        $result = [];
         $json = $this->resultFactory->create('json');
         $facetRequest = $this->requestFactory->create();
 
         $categoryId = $this->getRequest()->getParam('category');
-        //remove category id for now. It can give the wrong store id for the admin which results in the wrong tncid
-        //$facetRequest->addCategoryFilter($categoryId);
+        $allStores = $facetRequest->getStores();
 
-        $response = $this->client->request($facetRequest);
-        $result = [];
-        foreach ($response->getFacets() as $facet) {
-            $result[] = ['value' => $facet->getFacetSettings()->getUrlKey(), 'label' => $facet->getFacetSettings()->getTitle()];
+        foreach ($allStores as $store) {
+            $facetRequest->setStore($store->getId());
+            if (!empty($categoryId)) {
+                $facetRequest->addCategoryFilter($categoryId);
+            }
+
+            $response = $this->client->request($facetRequest);
+
+            foreach ($response->getFacets() as $facet) {
+                $result[] = ['value' => $facet->getFacetSettings()->getUrlKey(), 'label' => $facet->getFacetSettings()->getTitle()];
+            }
         }
+
+        $result = array_unique($result, SORT_REGULAR);
 
         $json->setData(['data' => $result]);
         return $json;

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -46,7 +46,12 @@ class Facets extends Action
         $facetRequest = $this->requestFactory->create();
 
         $categoryId = $this->getRequest()->getParam('category');
+        $filtertemplate = (int) $this->getRequest()->getParam('filtertemplate');
         $allStores = $facetRequest->getStores();
+
+        if (!empty($filtertemplate)) {
+            $facetRequest->addParameter('tn_ft', $filtertemplate);
+        }
 
         foreach ($allStores as $store) {
             $facetRequest->setStore($store->getId());

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -68,6 +68,9 @@ class Facets extends Action
 
         $result = array_unique($result, SORT_REGULAR);
 
+        //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
+        $result = array_values($result);
+
         $json->setData(['data' => $result]);
         return $json;
     }

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -66,6 +66,8 @@ class Facets extends Action
             }
         }
 
+        $result[] = ['value' => 'tw_other', 'label' => 'Other (text field)'];
+
         $result = array_unique($result, SORT_REGULAR);
 
         //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -236,6 +236,23 @@ class Request
     }
 
     /**
+     * @param $storeId
+     * @return void
+     */
+    public function setStore($storeId)
+    {
+        $this->storeManager->setCurrentStore((int) $storeId);
+    }
+
+    /**
+     * @return array|StoreInterface[]
+     */
+    public function getStores()
+    {
+        return $this->storeManager->getStores();
+    }
+
+    /**
      * @return StoreInterface|null
      */
     protected function getStore()


### PR DESCRIPTION
When you have multiple tweakwise instances (per store) only the facets of the first instance get returned. This pull request fixes that and returns the facets/facetattributes of all the stores.

It also checks which filtertemplate is selected. So it only returns attributes for that filtertemplate.