### PR TITLE
Fix filterpath url personal merchandising refresh

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -357,7 +357,15 @@ class PathSlugStrategy implements
 
         if (empty($currentFilterPath)) {
             $urlParts = parse_url($currentUrl);
-            $url = $urlParts['path'] . $newFilterPath;
+
+            $test = strpos($urlParts['path'], $newFilterPath);
+
+            if (strpos($urlParts['path'], $newFilterPath) === false) {
+                $url = $urlParts['path'] . $newFilterPath;
+            } else {
+                //filter path already exists in url
+                $url = $urlParts['path'];
+            }
             if (isset($urlParts['query'])) {
                 $url .= '?' . $urlParts['query'];
             }

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -358,8 +358,6 @@ class PathSlugStrategy implements
         if (empty($currentFilterPath)) {
             $urlParts = parse_url($currentUrl);
 
-            $test = strpos($urlParts['path'], $newFilterPath);
-
             if (strpos($urlParts['path'], $newFilterPath) === false) {
                 $url = $urlParts['path'] . $newFilterPath;
             } else {


### PR DESCRIPTION
Url filter path is wrong in the following case:

- Personal merchandising is enabled (causing an refresh on the first pageload of the category)
- Url stategy is seo path slugs.

When you select an filter in the catalog. Go to the pdp en go back to the catalog. The page refresh causes the filter values to be double. This pull request fixes that and prevents duplicate filters in the url