### PR TITLE
Fix ajax error in hyva theme

### DIFF
--- a/Model/AjaxNavigationResult.php
+++ b/Model/AjaxNavigationResult.php
@@ -95,7 +95,8 @@ class AjaxNavigationResult extends Layout
     public function render(HttpResponseInterface $response)
     {
         $html = $this->getLayout()->getOutput();
-        $html = preg_replace('/\s+/', ' ', $html);
+        //dont use \s. This causes javascript to break on comments because newlines are removed
+        $html = preg_replace('/\t+/', ' ', $html);
         $url  = $this->getResponseUrl();
 
         $responseData = $this->serializer->serialize(['url' => $url, 'html' => $html]);


### PR DESCRIPTION
When using the hyva theme and ajax navigation, you get js errors. These errors are caused by remove line endings in js for comments. This pull requests prevents the removal from line endings in the response to prevent js errors.

VM28277:1 Uncaught SyntaxError: Unexpected end of input
    at Proxy.ajaxUpdateBlocks (tops-men.html?product_list_order=Name:3327:52)
    at tops-men.html?product_list_order=Name:3251:30
ajaxUpdateBlocks 