### PR TITLE
Remove p=1 from ajax url

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -152,6 +152,11 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
         $params['_query'] = $query;
         $params['_escape'] = false;
 
+        //remove p=1 from url
+        if (!empty($params['_query']['p']) &&  ($params['_query']['p'] === "1")) {
+            unset($params['_query']['p']);
+        }
+
         if ($originalUrl = $request->getQuery('__tw_original_url')) {
 
             if (!empty($request->getParam('q'))){


### PR DESCRIPTION
When browsing in the PLP back to p1 from another page, the p=1 parameters gets added to the url. This only happens if ajax navigation is enabled and url strategy is set to 'query parameters'. This pull requests removes p=1 from the url.