### PR TITLE
Don't add categorie to search url on ajax pageload

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -141,6 +141,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
             self::PARAM_MODE,
             self::PARAM_PAGE,
             self::PARAM_ORDER,
+            self::PARAM_CATEGORY,
         ];
 
         foreach ($selectedFilters as $filter => $value) {


### PR DESCRIPTION
When stay in category is enabled in search, the ajax page load causes categorie to be added to the url. This bugfix prevents that.