### PR TITLE
Check if Item is tweakwise filter

### DIFF
--- a/Model/Seo/FilterHelper.php
+++ b/Model/Seo/FilterHelper.php
@@ -80,8 +80,10 @@ class FilterHelper
     public function shouldPageBeIndexable(): bool
     {
         foreach ($this->getActiveFilterItems() as $item) {
-            if (!$this->shouldFilterBeIndexable($item)) {
-                return false;
+            if ($item instanceof Item) {
+                if (!$this->shouldFilterBeIndexable($item)) {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
When the tweakwise api is down, the filter item returned is not an tweakwise filter. To prevent an error on item type, check if it is an tweakwise filter before checking if the filter is indexable.