### PR TITLE
Feature new category view

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/LinkRenderer/ItemRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/LinkRenderer/ItemRenderer.php
@@ -50,6 +50,11 @@ class ItemRenderer extends LinkRenderer
      */
     public function hasChildren()
     {
+        //link view should never show children. To be backwards compatible this only happens if the default linkrenderer is enabled.
+        if ($this->hasDefaultCategoryView()) {
+            return false;
+        }
+
         return $this->item->hasChildren();
     }
 

--- a/Block/LayeredNavigation/RenderLayered/SliderRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/SliderRenderer.php
@@ -15,6 +15,7 @@ use Magento\Tax\Helper\Data as TaxHelper;
 use Magento\Framework\Pricing\Helper\Data as PriceHelper;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\Serialize\Serializer\Json;
+use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 
 class SliderRenderer extends DefaultRenderer
 {
@@ -42,6 +43,7 @@ class SliderRenderer extends DefaultRenderer
      * @param FilterHelper $filterHelper
      * @param Template\Context $context
      * @param Json $jsonSerializer
+     * @param Helper $helper
      * @param array $data
      */
     public function __construct(
@@ -52,6 +54,7 @@ class SliderRenderer extends DefaultRenderer
         FilterHelper $filterHelper,
         Template\Context $context,
         Json $jsonSerializer,
+        Helper $helper,
         array $data = []
     ) {
         parent::__construct(
@@ -60,6 +63,7 @@ class SliderRenderer extends DefaultRenderer
             $navigationConfig,
             $filterHelper,
             $jsonSerializer,
+            $helper,
             $data
         );
         $this->priceHelper = $priceHelper;

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -13,6 +13,7 @@ use Magento\Catalog\Model\Category;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManager;
+use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class Request
 {
@@ -43,15 +44,21 @@ class Request
     protected $helper;
 
     /**
+     * @var Config
+     */
+    protected $config;
+    /**
      * Request constructor.
      *
      * @param Helper $helper
      * @param StoreManager $storeManager
+     * @param Config $config
      */
-    public function __construct(Helper $helper, StoreManager $storeManager)
+    public function __construct(Helper $helper, StoreManager $storeManager, Config $config)
     {
         $this->helper = $helper;
         $this->storeManager = $storeManager;
+        $this->config = $config;
     }
 
     /**
@@ -179,8 +186,34 @@ class Request
             $ids[] = $category;
             return $this->addCategoryPathFilter($ids);
         }
-        /** @var Category $category */
-        $parentIsRoot = in_array(
+
+        if($this->config->isCategoryViewDefault()) {
+            /** @var Category $category */
+            $parentIsRoot = $category;
+            while ($this->isCategoryRoot($parentIsRoot) === false) {
+                $ids[] = (int)$parentIsRoot->getParentId();
+                $parentIsRoot = $parentIsRoot->getParentCategory();
+            }
+            $ids[] = (int)$parentIsRoot->getParentId();
+
+            $ids = array_reverse($ids);
+        } else {
+            /** @var Category $category */
+            $parentIsRoot = $this->isCategoryRoot($category);
+
+            if (!$parentIsRoot) {
+                // Parent category is added so that category menu is retained on the deepest category level
+                $ids[] = (int) $category->getParentId();
+            }
+        }
+
+        $ids[] = (int) $category->getId();
+
+        return $this->addCategoryPathFilter($ids);
+    }
+
+    private function isCategoryRoot($category) {
+        return  in_array(
             (int) $category->getParentId(),
             [
                 0,
@@ -189,13 +222,6 @@ class Request
             ],
             true
         );
-        if (!$parentIsRoot) {
-            // Parent category is added so that category menu is retained on the deepest category level
-            $ids[] = (int) $category->getParentId();
-        }
-        $ids[] = (int) $category->getId();
-
-        return $this->addCategoryPathFilter($ids);
     }
 
     /**

--- a/Model/Client/Request/FacetAttributeRequest.php
+++ b/Model/Client/Request/FacetAttributeRequest.php
@@ -27,17 +27,6 @@ class FacetAttributeRequest extends Request
     protected $hiddenParameters = [];
 
     /**
-     * Request constructor.
-     *
-     * @param Helper $helper
-     * @param StoreManager $storeManager
-     */
-    public function __construct(Helper $helper, StoreManager $storeManager)
-    {
-        parent::__construct($helper, $storeManager);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getResponseType()

--- a/Model/Client/Request/ProductSearchRequest.php
+++ b/Model/Client/Request/ProductSearchRequest.php
@@ -25,19 +25,4 @@ class ProductSearchRequest extends ProductNavigationRequest implements SearchReq
      * {@inheritDoc}
      */
     protected $path = 'navigation-search';
-
-    /**
-     * ProductSearchRequest constructor.
-     * @param Helper $helper
-     * @param StoreManager $storeManager
-     * @param Config $config
-     */
-    public function __construct(
-        Helper $helper,
-        StoreManager $storeManager,
-        Config $config
-    ) {
-        parent::__construct($helper, $storeManager);
-        $this->config = $config;
-    }
 }

--- a/Model/Client/Request/Recommendations/FeaturedRequest.php
+++ b/Model/Client/Request/Recommendations/FeaturedRequest.php
@@ -17,6 +17,7 @@ use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Filter;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request;
 use Tweakwise\Magento2Tweakwise\Model\Client\Response\RecommendationsResponse;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
+use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class FeaturedRequest extends Request
 {
@@ -32,10 +33,10 @@ class FeaturedRequest extends Request
 
     protected $registery;
 
-    public function __construct(Helper $helper, StoreManager $storeManager, Registry $registry)
+    public function __construct(Helper $helper, StoreManager $storeManager, Registry $registry, Config $config)
     {
         $this->registery = $registry;
-        parent::__construct($helper, $storeManager);
+        parent::__construct($helper, $storeManager, $config);
     }
 
     /**

--- a/Model/Client/Request/Suggestions/ProductSuggestionsRequest.php
+++ b/Model/Client/Request/Suggestions/ProductSuggestionsRequest.php
@@ -20,21 +20,6 @@ class ProductSuggestionsRequest extends Request implements SearchRequestInterfac
     protected $path = 'suggestions/products';
 
     /**
-     * ProductSuggestionRequest constructor.
-     * @param Helper $helper
-     * @param StoreManager $storeManager
-     * @param Config $config
-     */
-    public function __construct(
-        Helper $helper,
-        StoreManager $storeManager,
-        Config $config
-    ) {
-        parent::__construct($helper, $storeManager);
-        $this->config = $config;
-    }
-
-    /**
      * @return string
      */
     public function getResponseType()

--- a/Model/Client/Request/Suggestions/SuggestionsRequest.php
+++ b/Model/Client/Request/Suggestions/SuggestionsRequest.php
@@ -20,21 +20,6 @@ class SuggestionsRequest extends Request implements SearchRequestInterface
     protected $path = 'suggestions';
 
     /**
-     * SuggestionRequest constructor.
-     * @param Helper $helper
-     * @param StoreManager $storeManager
-     * @param Config $config
-     */
-    public function __construct(
-        Helper $helper,
-        StoreManager $storeManager,
-        Config $config
-    ) {
-        parent::__construct($helper, $storeManager);
-        $this->config = $config;
-    }
-
-    /**
      * @return string
      */
     public function getResponseType()

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -598,4 +598,13 @@ class Config
         }
         return $salt;
     }
+
+    /**
+     * @param Store|null $store
+     * @return int
+     */
+    public function isCategoryViewDefault(Store $store = null)
+    {
+        return $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
+    }
 }

--- a/Model/Config/Source/CategoryView.php
+++ b/Model/Config/Source/CategoryView.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tweakwise (https://www.tweakwise.com/) - All Rights Reserved
+ *
+ * @copyright Copyright (c) 2017-2022 Tweakwise.com B.V. (https://www.tweakwise.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Tweakwise\Magento2Tweakwise\Model\Config\Source;
+
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\PathSlugStrategy;
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class CategoryView implements OptionSourceInterface
+{
+    /**
+     * Possible filter types
+     */
+    public const EXTENDED = 1;
+    public const SIMPLE = 0;
+
+    /**
+     * @var array[]
+     */
+    protected $options;
+
+    /**
+     * @return array
+     */
+    protected function buildOptions()
+    {
+        return [
+            ['value' => self::EXTENDED, 'label' => __('Extended')],
+            ['value' => self::SIMPLE, 'label' => __('Simple (deprecated)')],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toOptionArray()
+    {
+        if (!$this->options) {
+            $this->options = $this->buildOptions();
+        }
+        return $this->options;
+    }
+}

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -63,6 +63,7 @@ class InstallData implements InstallDataInterface
         $this->ensureUpsellTemplateAttribute($eavSetup);
         $this->ensureFeaturedTemplateAttribute($eavSetup);
         $this->updateNavigatorBaseUrl();
+        $this->setDefaultCategoryView();
 
         $setup->endSetup();
     }
@@ -139,5 +140,13 @@ class InstallData implements InstallDataInterface
     protected function updateNavigatorBaseUrl()
     {
         $this->writer->save('tweakwise/general/server_url', 'https://gateway.tweakwisenavigator.com/');
+    }
+
+    /**
+     * Set default category view for new installs only
+     */
+    protected function setDefaultCategoryView()
+    {
+        $this->writer->save('tweakwise/layered/default_category_view', 1);
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -89,6 +89,14 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="default_category_view" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Default Category View</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                        <field id="default_link_renderer">0</field>
+                    </depends>
+                </field>
             </group>
             <group id="seo" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -90,8 +90,8 @@
                     </depends>
                 </field>
                 <field id="default_category_view" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Default Category View</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <label>Category View</label>
+                    <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\CategoryView</source_model>
                     <depends>
                         <field id="enabled">1</field>
                         <field id="default_link_renderer">0</field>


### PR DESCRIPTION
The category view in magento is not on all (sub)category levels the same as the TW demoshop. This pull requests adds an setting to change the category view to the same view as the TW demoshop. 

The setting 'category view' is set default to 'simple'. That is the current category view. So for the customers nothing changes unless the change this setting.

If the setting is changed to 'extended'. The category view is changed to the same view as the TW denmoshop.