### PR TITLE
better fix for duplicate store codes in url

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -535,7 +535,7 @@ class PathSlugStrategy implements
         }
 
         $category = $this->strategyHelper->getCategoryFromItem($item);
-        $categoryUrlPath = \parse_url($category->getUrl(), PHP_URL_PATH);
+        $categoryUrlPath = str_replace($this->magentoUrl->getBaseUrl(), '', $category->getUrl());
 
         $url = $this->magentoUrl->getDirectUrl(
             sprintf(
@@ -552,26 +552,6 @@ class PathSlugStrategy implements
         if (!empty($filterSlugPath)) {
             $url.= '/' . trim($filterSlugPath, '/');
         }
-
-        /*
-         We explode the url so that we can capture its parts and find the double values in order to remove them.
-         This is needed because the categoryUrlPath contains the store code in some cases and the directUrl as well.
-         These two are the only unique parts in this situation and so need to be removed.
-         */
-
-        $explode = explode('/', $url);
-
-        // Filter out consecutive duplicate values
-        $filteredParts = [];
-        $prevPart = null;
-        foreach ($explode as $part) {
-            if ($part !== $prevPart) {
-                $filteredParts[] = $part;
-            }
-            $prevPart = $part;
-        }
-
-        $url = implode('/', $filteredParts);
 
         //remove double slashes with exception for the protocol
         $url = preg_replace('#(?<!:)//+#', '/', $url);

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -222,8 +222,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
     {
         $category = $this->strategyHelper->getCategoryFromItem($item);
         if (!$this->getSearch($request)) {
-            $categoryUrl = $category->getUrl();
-            $categoryUrlPath = \parse_url($categoryUrl, PHP_URL_PATH);
+            $categoryUrlPath = str_replace($this->url->getBaseUrl(), '', $category->getUrl());
 
             $url = $this->url->getDirectUrl(
                 sprintf(
@@ -234,19 +233,6 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
                     ]
                 )
             );
-
-
-            /*
-             We explode the url so that we can capture its parts and find the double values in order to remove them.
-             This is needed because the categoryUrlPath contains the store code in some cases and the directUrl as well.
-             These two are the only unique parts in this situation and so need to be removed.
-             */
-
-            $explode = explode('/', $url);
-
-            if (is_array($explode)) {
-                $url = implode('/', array_unique($explode));
-            }
 
             $url = str_replace($this->url->getBaseUrl(), '', $url);
 
@@ -429,7 +415,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
             $query = $request->getQuery();
             $query->set(SELF::PARAM_ORDER, $sortOrder);
             $request->setQuery($query);
-            
+
             $navigationRequest->setOrder($sortOrder);
         }
 


### PR DESCRIPTION
With `\parse_url()` the storecode will be added to the `$categoryUrlPath` when `web/url/use_store` is enabled, that's why later in the code duplicate values are removed with `implode('/', array_unique(explode('/', $url)));` or  the other technique in `PathSlugStrategy`.

But this will also filter out deliberate duplicate values, like `/men/lifestyle/clothes/sweaters/sweaters` to `/men/lifestyle/clothes/sweaters`. So with this MR we change `\parse_url()` and just strip off the base url directly with a string replace. Because the base url also has te store code in it, when the `web/url/use_store` is enabled, so the path will never have the store code in it and we don't need tricks to strip of duplicate values. 