### PR TITLE
Don't add prefix for root category 1

### DIFF
--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -234,11 +234,11 @@ class Request
         $storeId = (int) $this->getStoreId();
         $tweakwiseIdMapper = function (int $categoryId) use ($storeId) {
             //don't add prefix for root category 1.
-            if ($categoryId !== 1) {
-                return $this->helper->getTweakwiseId($storeId, $categoryId);
-            } else {
+            if ($categoryId === 1) {
                 return $categoryId;
             }
+            
+            return $this->helper->getTweakwiseId($storeId, $categoryId);
         };
         $tweakwiseIds = array_map($tweakwiseIdMapper, $categoryIds);
         $this->setParameter('tn_cid', implode('-', $tweakwiseIds));

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -235,9 +235,9 @@ class Request
         $tweakwiseIdMapper = function (int $categoryId) use ($storeId) {
             //don't add prefix for root category 1.
             if ($categoryId === 1) {
-                return $categoryId;
+                return '';
             }
-            
+
             return $this->helper->getTweakwiseId($storeId, $categoryId);
         };
         $tweakwiseIds = array_map($tweakwiseIdMapper, $categoryIds);

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -233,7 +233,12 @@ class Request
         $categoryIds = array_map('intval', $categoryIds);
         $storeId = (int) $this->getStoreId();
         $tweakwiseIdMapper = function (int $categoryId) use ($storeId) {
-            return $this->helper->getTweakwiseId($storeId, $categoryId);
+            //don't add prefix for root category 1.
+            if ($categoryId !== 1) {
+                return $this->helper->getTweakwiseId($storeId, $categoryId);
+            } else {
+                return $categoryId;
+            }
         };
         $tweakwiseIds = array_map($tweakwiseIdMapper, $categoryIds);
         $this->setParameter('tn_cid', implode('-', $tweakwiseIds));

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -606,11 +606,6 @@ class Config
      */
     public function isCategoryViewDefault(Store $store = null)
     {
-        $categoryViewDefault = $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
-
-        if ($categoryViewDefault !== "1") {
-            return 0;
-        }
-        return 1;
+        return $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -606,6 +606,11 @@ class Config
      */
     public function isCategoryViewDefault(Store $store = null)
     {
-        return $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
+        $cateogryViewExtended = $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
+
+        if ($cateogryViewExtended !== "1") {
+            return 0;
+        }
+        return 1;
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -606,9 +606,9 @@ class Config
      */
     public function isCategoryViewDefault(Store $store = null)
     {
-        $cateogryViewExtended = $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
+        $categoryViewDefault = $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
 
-        if ($cateogryViewExtended !== "1") {
+        if ($categoryViewDefault !== "1") {
             return 0;
         }
         return 1;

--- a/Model/Config/Source/CategoryView.php
+++ b/Model/Config/Source/CategoryView.php
@@ -31,8 +31,8 @@ class CategoryView implements OptionSourceInterface
     protected function buildOptions()
     {
         return [
-            ['value' => self::EXTENDED, 'label' => __('Extended')],
             ['value' => self::SIMPLE, 'label' => __('Simple (deprecated)')],
+            ['value' => self::EXTENDED, 'label' => __('Extended')],
         ];
     }
 


### PR DESCRIPTION
When using the suggestions api. And stay in category is enabled. You can get an error on the homepage because the root category is send wrong to tweakwise. All categories have prefixes with the store id. But the root category doesn't have an prefix because it's the default category in TW. It just has an id of 1 in tweakwise.

This pull requests changes the category filter to 1 instead of 100011. This prevents an 500 error on the TW side.