### PR TITLE
Fix url path for refreshing

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -314,7 +314,16 @@ class PathSlugStrategy implements
             return str_replace($this->magentoUrl->getBaseUrl(), '', $url);
         }
 
-        return $this->getCurrentUrl($request);
+        $url = $this->getCurrentUrl($request);
+
+        $filterPath = $this->buildFilterSlugPath($this->getActiveFilters());
+
+        //remove active filters from url,this causes the url to be wrong on page refresh
+        if (strpos($url, $filterPath) !== false) {
+            $url = str_replace($filterPath, '', $url);
+        }
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
When you've have url pathslug strategy enabled. And you go to an category page and select an filter. If you refresh the page, the url will be wrong if you select another filter. This pull request fixes that