### PR TITLE
Fix parent category

### DIFF
--- a/Model/Catalog/Layer/Filter/Item.php
+++ b/Model/Catalog/Layer/Filter/Item.php
@@ -126,7 +126,7 @@ class Item extends MagentoItem
             return $this->url->getSliderUrl($this);
         }
 
-        if ($this->isSelected() && $settings->getSelectionType() !== SettingsType::SOURCE_CATEGORY) {
+        if ($this->isSelected() && ($settings->getSource() !== SettingsType::SOURCE_CATEGORY)) {
             return $this->url->getRemoveFilter($this);
         }
 


### PR DESCRIPTION
Fixes #81 

The bug only happens in the parent category if you have selected an category three levels deep. And it only shows if you show the entire category tree.