### PR TITLE
Bugfix double category name for default magento renderer

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -249,6 +249,10 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
 
             $url = str_replace($this->url->getBaseUrl(), '', $url);
 
+            if ($this->tweakwiseConfig->getUseDefaultLinkRenderer()) {
+                $url = '/' . $url;
+            }
+
             return $url;
         }
 


### PR DESCRIPTION
When the default magento renderer is set to yes, you get the current url + category url. If you're in an subcategory this causes the wrong url. This pull request fixes that.