### PR TITLE
Add isset for attributes

### DIFF
--- a/Model/Client/Response/FacetAttributesResponse.php
+++ b/Model/Client/Response/FacetAttributesResponse.php
@@ -47,6 +47,9 @@ class FacetAttributesResponse extends Response
     }
 
     public function getAttributes(){
-        return $this->data['attributes'];
+        if (isset($this->data['attributes'])) {
+            return $this->data['attributes'];
+        }
+        return [];
     }
 }


### PR DESCRIPTION
This fixes an bug with ALP facet values where the values for specific stores can be empty