### PR TITLE
Bugfix prevent 500 error

### DIFF
--- a/Block/Catalog/Product/ProductList/Toolbar/Plugin.php
+++ b/Block/Catalog/Product/ProductList/Toolbar/Plugin.php
@@ -79,6 +79,11 @@ class Plugin
             return $proceed();
         }
 
+        if (empty($this->context->getResponse())) {
+            //no response from TW
+            return $proceed();
+        }
+
         /** @var SortFieldType[] $sortFields */
         $sortFields = $this->context->getResponse()->getProperties()->getSortFields();
 

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,7 +358,8 @@ define([
          * @private
          */
         _updateState: function (response) {
-            window.history.pushState({html: response.html}, '', response.url);
+            const newUrl = this._buildUrlWithQueryString(response, true);
+            window.history.pushState({html: response.html}, '', newUrl);
         },
 
         /**
@@ -374,17 +375,22 @@ define([
          * Merges existed query parameters with the ones get from AJAX response if needed
          *
          * @param response
+         * @param flip
          * @returns string
          * @private
          */
-        _buildUrlWithQueryString: function (response) {
+        _buildUrlWithQueryString: function (response, flip = false) {
             const baseUrl = window.location.origin;
             const resultUrl = new URL(response.url, baseUrl);
             const queryParams = new URLSearchParams(window.location.search ?? '');
             let queryParamsString = queryParams.toString();
 
             if (resultUrl.search) {
-                queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
+                if (flip) {
+                    queryParamsString = this._combineQueryStrings(resultUrl.searchParams, queryParams);
+                } else {
+                    queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
+                }
             }
 
             resultUrl.search = queryParamsString;

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -358,8 +358,7 @@ define([
          * @private
          */
         _updateState: function (response) {
-            const newUrl = this._buildUrlWithQueryString(response, true);
-            window.history.pushState({html: response.html}, '', newUrl);
+            window.history.pushState({html: response.html}, '', response.url);
         },
 
         /**
@@ -375,22 +374,17 @@ define([
          * Merges existed query parameters with the ones get from AJAX response if needed
          *
          * @param response
-         * @param flip
          * @returns string
          * @private
          */
-        _buildUrlWithQueryString: function (response, flip = false) {
+        _buildUrlWithQueryString: function (response) {
             const baseUrl = window.location.origin;
             const resultUrl = new URL(response.url, baseUrl);
             const queryParams = new URLSearchParams(window.location.search ?? '');
             let queryParamsString = queryParams.toString();
 
             if (resultUrl.search) {
-                if (flip) {
-                    queryParamsString = this._combineQueryStrings(resultUrl.searchParams, queryParams);
-                } else {
-                    queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
-                }
+                queryParamsString = this._combineQueryStrings(queryParams, resultUrl.searchParams);
             }
 
             resultUrl.search = queryParamsString;

--- a/view/frontend/web/js/pm-page-reload.js
+++ b/view/frontend/web/js/pm-page-reload.js
@@ -1,7 +1,7 @@
 /**
  * Tweakwise (https://www.tweakwise.com/) - All Rights Reserved
  *
- * @copyright Copyright (c) 2017-2022 Tweakwise.com B.V. (https://www.tweakwise.com)
+ * @copyright Copyright (c) 2017-2023 Tweakwise.com B.V. (https://www.tweakwise.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -27,6 +27,11 @@ define([
                 && this.options.cookieName
                 && ($.mage.cookies.get(this.options.cookieName) !== null);
             if (reload) {
+                const urlParams = new URLSearchParams(window.location.search);
+                const pageParam = urlParams.get('p');
+                if (pageParam) {
+                    $(this.element.append('<input type="hidden" name="p" value="'+ parseInt(pageParam) +'" />'))
+                }
                 this.element.trigger('change');
             }
         }


### PR DESCRIPTION
When tweakwise is down, an search request causes an 500 error. This pull request fixes this by returning the default response for an search

Fixes #149 