### PR TITLE
Prevent duplicate slug values

### DIFF
--- a/Api/Data/AttributeSlugInterface.php
+++ b/Api/Data/AttributeSlugInterface.php
@@ -18,6 +18,7 @@ interface AttributeSlugInterface
     public function getSlug(): string;
 
     /**
+     * @param string $slug
      * @return void
      */
     public function setSlug(string $slug): void;

--- a/Api/Data/AttributeSlugInterface.php
+++ b/Api/Data/AttributeSlugInterface.php
@@ -16,4 +16,9 @@ interface AttributeSlugInterface
      * @return string
      */
     public function getSlug(): string;
+
+    /**
+     * @return void
+     */
+    public function setSlug(string $slug): void;
 }

--- a/Model/AttributeSlug.php
+++ b/Model/AttributeSlug.php
@@ -53,6 +53,7 @@ class AttributeSlug extends AbstractModel implements AttributeSlugInterface
 
     /**
      * @param string $slug
+     * @return void
      */
     public function setSlug(string $slug): void
     {

--- a/Model/AttributeSlug.php
+++ b/Model/AttributeSlug.php
@@ -54,7 +54,7 @@ class AttributeSlug extends AbstractModel implements AttributeSlugInterface
     /**
      * @param string $slug
      */
-    public function setSlug(string $slug)
+    public function setSlug(string $slug): void
     {
         $this->setData(self::SLUG, $slug);
     }

--- a/Model/AttributeSlugRepository.php
+++ b/Model/AttributeSlugRepository.php
@@ -82,11 +82,12 @@ class AttributeSlugRepository implements AttributeSlugRepositoryInterface
                 $existingSlug = $this->findBySlug($attributeSlug->getSlug());
 
                 //slug exists, check if it is not the current attribute saved
-                if ($attributeSlug->getAttribute() != $existingSlug->getAttribute()) {
+                if ($attributeSlug->getAttribute() !== $existingSlug->getAttribute()) {
                     $newSlug = $attributeSlug->getSlug();
-                    $newSlug .= '-';
+                    $counter = 0;
                     while ($newSlug === $this->findBySlug($newSlug)->getSlug()) {
-                        $newSlug .= '-';
+                        $counter++;
+                        $newSlug = sprintf('%s-%s', $attributeSlug->getSlug(), $counter);
                     }
                 }
                 /** @var AttributeSlug $attributeSlug */
@@ -167,13 +168,14 @@ class AttributeSlugRepository implements AttributeSlugRepositoryInterface
      */
     public function findBySlug(string $slug): AttributeSlugInterface
     {
-        $attributeSlug = $this->entityFactory->create();
-        $collection = $attributeSlug->getCollection();
-        $collection->addFieldToFilter('slug', $slug);
-        $collection->load();
+        $collection = $this->collectionFactory->create()
+            ->addFieldToFilter('slug', $slug);
         if (!$collection->getSize()) {
-            throw new NoSuchEntityException(__('No slug found for attribute "%s".', $slug));
+            throw new NoSuchEntityException(__('No slug found for attribute "%1".', $slug));
         }
-        return $collection->getFirstItem();
+
+        /** @var AttributeSlug $attributeSlug */
+        $attributeSlug = $collection->getFirstItem();
+        return $attributeSlug;
     }
 }


### PR DESCRIPTION
When attribute values have different spellings (Black and Black"), that may cause filters to return no products.

**How to Reproduce the Issue:**

1. Utilize the path slug for the URL strategy.
2. Create an attribute with identical values but different spellings. For instance, "Black," "black," or "black''."
3. This leads to duplicate values in the `tweakwise_attribute_slug` table. This may cause (depending on the order) to cause an tweakwise filter with the same value to return no products.

**How to test**
1. Utilize the path slug for the URL strategy.
2. Create an attribute with identical values but different spellings. For instance, "Black," "black," or "black''."
3. Check if the tweakwise_attribute_slug table has duplicate values.

**Solution Implemented in the Pull Request:**

To address this issue, the pull request introduces a fix by appending an extra dash and an number at the end of the slug value. This ensures that the slug value remains unique at all times. To fix duplicate values the only thing the customer has to do is to save the attribute with duplicate values.
