### PR TITLE
feat: Searchable filters

### DIFF
--- a/Api/Data/AttributeSlugInterface.php
+++ b/Api/Data/AttributeSlugInterface.php
@@ -16,4 +16,10 @@ interface AttributeSlugInterface
      * @return string
      */
     public function getSlug(): string;
+
+    /**
+     * @param string $slug
+     * @return void
+     */
+    public function setSlug(string $slug): void;
 }

--- a/Block/Checkout/Cart/Crosssell/Plugin.php
+++ b/Block/Checkout/Cart/Crosssell/Plugin.php
@@ -248,6 +248,7 @@ class Plugin extends AbstractRecommendationPlugin
      */
     protected function _getCartProducts()
     {
+        $products = [];
         foreach ($this->getQuote()->getAllItems() as $quoteItem) {
             /* @var $quoteItem \Magento\Quote\Model\Quote\Item */
             $product = $quoteItem->getProduct();
@@ -276,6 +277,8 @@ class Plugin extends AbstractRecommendationPlugin
         if (!empty($cartItems)) {
             $collection = $this->removeCartItems($collection, $cartItems);
         }
+
+        $items = [];
 
         foreach ($collection as $item) {
             $items[] = $item;

--- a/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
@@ -198,7 +198,7 @@ class DefaultRenderer extends Template
      */
     public function isSearchable()
     {
-        return ($this->getFacetSettings()->getBoolValue('issearchable') && $this->hasHiddenItems() );
+        return ($this->getFacetSettings()->isSearchable() && $this->hasHiddenItems());
     }
 
     /**
@@ -206,7 +206,7 @@ class DefaultRenderer extends Template
      */
     public function getSearchPlaceholder()
     {
-        return empty($this->getFacetSettings()->getValue('searchplaceholder')) ? '' : $this->getFacetSettings()->getValue('searchplaceholder');
+        return $this->getFacetSettings()->getSearchPlaceholder();
     }
 
     /**
@@ -214,7 +214,7 @@ class DefaultRenderer extends Template
      */
     public function getSearchNoResultsText()
     {
-        return empty($this->getFacetSettings()->getValue('searchnoresultstext')) ? '' : $this->getFacetSettings()->getValue('searchnoresultstext');
+        return $this->getFacetSettings()->getSearchNoResultsText();
     }
 
     /**

--- a/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
@@ -196,6 +196,30 @@ class DefaultRenderer extends Template
     /**
      * @return bool
      */
+    public function isSearchable()
+    {
+        return ($this->getFacetSettings()->getBoolValue('issearchable') && $this->hasHiddenItems() );
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchPlaceholder()
+    {
+        return empty($this->getFacetSettings()->getValue('searchplaceholder')) ? '' : $this->getFacetSettings()->getValue('searchplaceholder');
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchNoResultsText()
+    {
+        return empty($this->getFacetSettings()->getValue('searchnoresultstext')) ? '' : $this->getFacetSettings()->getValue('searchnoresultstext');
+    }
+
+    /**
+     * @return bool
+     */
     public function shouldDisplayProductCountOnLayer()
     {
         return $this->getFacetSettings()->getIsNumberOfResultVisible();

--- a/Block/LayeredNavigation/RenderLayered/SwatchRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/SwatchRenderer.php
@@ -212,4 +212,28 @@ class SwatchRenderer extends RenderLayered
     {
         return $this->getFacetSettings()->getIsNumberOfResultVisible();
     }
+
+    /**
+     * @return bool
+     */
+    public function isSearchable()
+    {
+        return $this->getFacetSettings()->isSearchable();
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchPlaceholder()
+    {
+        return $this->filter->getFacet()->getFacetSettings()->getSearchPlaceholder();
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchNoResultsText()
+    {
+        return $this->filter->getFacet()->getFacetSettings()->getSearchNoResultsText();
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,3 +188,7 @@ We've added a setting in which you can define whether to use the old/existing wa
 - Implemented a preventive measure to avoid errors when no attribute values are present for ALP facet requests. 
 - Resolved the issue with personal merchandising and pagination not functioning correctly when utilising the filter form.
 - Implemented measures to prevent a 500 error in the search when Tweakwise is inaccessible or down.
+
+## 5.8.3
+- Implemented prevention of duplicate attribute slug values. Previously, attribute values with variations in their representations, such as Black and Black", resulted in duplicate entries in the tweakwise_attribute_slug table. This duplication could disrupt filter functionality if the incorrect value was retrieved. This pull request addresses the issue by appending a unique identifier ("-") followed by a number to each slug, ensuring their uniqueness. Note that attributes with previously duplicated slug values will require re-saving to activate this fix.
+- Resolved a notice issue pertaining to missing variables when the shopping cart is empty. Previously, certain sections of the application would trigger notices due to uninitialized variables when the cart was empty.

--- a/Model/AttributeSlug.php
+++ b/Model/AttributeSlug.php
@@ -53,8 +53,9 @@ class AttributeSlug extends AbstractModel implements AttributeSlugInterface
 
     /**
      * @param string $slug
+     * @return void
      */
-    public function setSlug(string $slug)
+    public function setSlug(string $slug): void
     {
         $this->setData(self::SLUG, $slug);
     }

--- a/Model/Client/Type/FacetType/SettingsType.php
+++ b/Model/Client/Type/FacetType/SettingsType.php
@@ -201,4 +201,27 @@ class SettingsType extends Type
         }
         return null;
     }
+    /**
+     * @return bool
+     */
+    public function isSearchable()
+    {
+        return ($this->getBoolValue('issearchable'));
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchPlaceholder()
+    {
+        return empty($this->getValue('searchplaceholder')) ? '' : $this->getValue('searchplaceholder');
+    }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getSearchNoResultsText()
+    {
+        return empty($this->getValue('searchnoresultstext')) ? '' : $this->getValue('searchnoresultstext');
+    }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -12,7 +12,7 @@
         <section id="tweakwise">
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General</label>
-                <comment>Tweakwise version v5.8.2</comment>
+                <comment>Tweakwise version v5.8.3</comment>
                 <field id="authentication_key" translate="label,comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Authentication key</label>
                     <comment>Provided by Tweakwise (8 alphanumeric characters)</comment>

--- a/view/frontend/templates/product/layered/default.phtml
+++ b/view/frontend/templates/product/layered/default.phtml
@@ -17,6 +17,10 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
 
 ?>
 <div data-mage-init='<?=$block->getJsSortConfig()?>'>
+    <?php if ($block->isSearchable()): ?>
+        <input type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+    <?php endif; ?>
     <ol class="items">
         <?php foreach ($block->getItems() as $index => $item): ?>
             <li class="item<?=$block->itemDefaultHidden($item) ? ' default-hidden' : ''?>"
@@ -63,3 +67,47 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
         <a class="less-items default-hidden"><?=__($block->getLessItemText())?></a>
     <?php endif; ?>
 </div>
+
+<script>
+    require(["jquery"], function ($) {
+        $("input[name='tw_filtersearch']").on("keyup", function() {
+
+            var value = $(this).val().toLowerCase().trim();
+            var items = $(this).parent('div').find('ol');
+            var noItems = $(this).parent('div').find('.tw_search_no_results');
+            var defaultVisibleItems = <?= $block->getMaxItemsShown(); ?>;
+
+
+            items.find('li').show().filter(function () {
+                return $(this).find('input').val().toLowerCase().trim().indexOf(value) == -1;
+            }).hide();
+
+            //hide show more/less button
+            if (value.length == 0) {
+                $(this).parent('div').find('.more-items').show();
+            } else {
+                $(this).parent('div').find('.more-items').hide();
+                $(this).parent('div').find('.less-items').hide();
+            }
+
+            if(defaultVisibleItems < items.find('li:visible').length) {
+                //more items visible then max visible items set on filter
+                var counter = -1;
+                items.find('li:visible').show().filter(function () {
+                    if ((counter) > defaultVisibleItems) {
+                        return true;
+                    }
+                    counter++;
+                    return false;
+                }).hide();
+            }
+
+            //no items found
+            if (items.find('li:visible').length < 1) {
+                noItems.show();
+            } else {
+                noItems.hide();
+            }
+        });
+    });
+</script>

--- a/view/frontend/templates/product/layered/default.phtml
+++ b/view/frontend/templates/product/layered/default.phtml
@@ -19,7 +19,7 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
 <div data-mage-init='<?=$block->getJsSortConfig()?>'>
     <?php if ($block->isSearchable()): ?>
         <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
-        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+        <div style="display: none" class="search_no_results"><?= $block->getSearchNoResultsText(); ?></div>
     <?php endif; ?>
     <ol class="items">
         <?php foreach ($block->getItems() as $index => $item): ?>

--- a/view/frontend/templates/product/layered/default.phtml
+++ b/view/frontend/templates/product/layered/default.phtml
@@ -18,7 +18,7 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
 ?>
 <div data-mage-init='<?=$block->getJsSortConfig()?>'>
     <?php if ($block->isSearchable()): ?>
-        <input type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
         <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
     <?php endif; ?>
     <ol class="items">
@@ -67,47 +67,3 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
         <a class="less-items default-hidden"><?=__($block->getLessItemText())?></a>
     <?php endif; ?>
 </div>
-
-<script>
-    require(["jquery"], function ($) {
-        $("input[name='tw_filtersearch']").on("keyup", function() {
-
-            var value = $(this).val().toLowerCase().trim();
-            var items = $(this).parent('div').find('ol');
-            var noItems = $(this).parent('div').find('.tw_search_no_results');
-            var defaultVisibleItems = <?= $block->getMaxItemsShown(); ?>;
-
-
-            items.find('li').show().filter(function () {
-                return $(this).find('input').val().toLowerCase().trim().indexOf(value) == -1;
-            }).hide();
-
-            //hide show more/less button
-            if (value.length == 0) {
-                $(this).parent('div').find('.more-items').show();
-            } else {
-                $(this).parent('div').find('.more-items').hide();
-                $(this).parent('div').find('.less-items').hide();
-            }
-
-            if(defaultVisibleItems < items.find('li:visible').length) {
-                //more items visible then max visible items set on filter
-                var counter = -1;
-                items.find('li:visible').show().filter(function () {
-                    if ((counter) > defaultVisibleItems) {
-                        return true;
-                    }
-                    counter++;
-                    return false;
-                }).hide();
-            }
-
-            //no items found
-            if (items.find('li:visible').length < 1) {
-                noItems.show();
-            } else {
-                noItems.hide();
-            }
-        });
-    });
-</script>

--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -15,7 +15,7 @@
      data-mage-init='{"tweakwiseNavigationSort":[]}'>
     <?php if ($block->isSearchable()): ?>
         <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
-        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+        <div style="display: none" class="no_search_results"><?= $block->getSearchNoResultsText(); ?></div>
     <?php endif; ?>
     <div class="swatch-attribute-options clearfix">
         <?php foreach ($swatchData['options'] as $option => $label): ?>

--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -13,6 +13,10 @@
      attribute-code="<?= /* @escapeNotVerified */ $swatchData['attribute_code'] ?>"
      attribute-id="<?= /* @escapeNotVerified */ $swatchData['attribute_id'] ?>"
      data-mage-init='{"tweakwiseNavigationSort":[]}'>
+    <?php if ($block->isSearchable()): ?>
+        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+    <?php endif; ?>
     <div class="swatch-attribute-options clearfix">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
             <?php $item = $block->getItemForSwatch($option);?>

--- a/view/frontend/web/css/style.less
+++ b/view/frontend/web/css/style.less
@@ -141,7 +141,7 @@
                 width: 24px;
             }
         }
-        
+
         input[type='checkbox']:checked {
             + label .swatch-option {
                 outline: 2px solid #ee0000;
@@ -215,6 +215,11 @@
                 bottom: ~"calc(100% + 10px)";
             }
         }
+    }
+
+    .no_search_results {
+        display: none;
+        padding-top: 10px;
     }
 }
 

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -211,6 +211,10 @@ define([
         _ajaxHandler: function (event) {
             event.preventDefault();
 
+            if(event.target.name == 'tw_filtersearch') {
+                return;
+            }
+
             if (this.currentXhr) {
                 this.currentXhr.abort();
             }

--- a/view/frontend/web/js/navigation-sort.js
+++ b/view/frontend/web/js/navigation-sort.js
@@ -79,30 +79,23 @@ define([
             var filterInput = this.element.find('.tw_filtersearch');
             var value = filterInput.val().toLowerCase().trim();
             var items = filterInput.parent('div').find('ol');
-            var noItems = filterInput.parent('div').find('.tw_search_no_results');
+            var noItems = filterInput.parent('div').find('.no_search_results');
             var defaultVisibleItems = filterInput.data('max-visible');
             var counter = -1;
             var filterElement = 'li'
 
-            if (items.length == 0) {
+            if (items.length === 0) {
                 //swatch
                 items = filterInput.parent('div');
                 filterElement = 'a';
                 defaultVisibleItems = 100;
             }
 
-
             items.find(filterElement).show().filter(function () {
-                //dont hide selected values
-                if ($(this).find('input').is(":checked")) {
-                    counter++;
-                    return false;
-                }
-                console.log($(this).find('input').val());
-                return $(this).find('input').val().toLowerCase().trim().indexOf(value) == -1;
+                return $(this).find('input').val().toLowerCase().trim().indexOf(value) === -1;
             }).hide();
 
-            if(defaultVisibleItems < items.find(filterElement +':visible').length) {
+            if (defaultVisibleItems < items.find(filterElement +':visible').length) {
                 //more items visible then max visible items set on filter
                 items.find(filterElement + ':visible').show().filter(function () {
                     if ((counter) > defaultVisibleItems) {
@@ -120,9 +113,8 @@ define([
                 noItems.hide();
             }
 
-
             //hide show more/less button
-            if (value.length == 0) {
+            if (value.length === 0) {
                 filterInput.parent('div').find('.more-items').show();
             } else {
                 filterInput.parent('div').find('.more-items').hide();

--- a/view/frontend/web/js/navigation-sort.js
+++ b/view/frontend/web/js/navigation-sort.js
@@ -27,6 +27,7 @@ define([
         _hookEvents: function () {
             this.element.on('click', '.more-items', this._handleMoreItemsLink.bind(this));
             this.element.on('click', '.less-items', this._handleLessItemsLink.bind(this));
+            this.element.on('keyup', '.tw_filtersearch', this._handleFilterSearch.bind(this));
         },
 
         /**
@@ -72,6 +73,61 @@ define([
             list.children('.item').sort(function (a, b) {
                 return $(a).data(type) - $(b).data(type);
             }).appendTo(list);
+        },
+
+        _handleFilterSearch: function () {
+            var filterInput = this.element.find('.tw_filtersearch');
+            var value = filterInput.val().toLowerCase().trim();
+            var items = filterInput.parent('div').find('ol');
+            var noItems = filterInput.parent('div').find('.tw_search_no_results');
+            var defaultVisibleItems = filterInput.data('max-visible');
+            var counter = -1;
+            var filterElement = 'li'
+
+            if (items.length == 0) {
+                //swatch
+                items = filterInput.parent('div');
+                filterElement = 'a';
+                defaultVisibleItems = 100;
+            }
+
+
+            items.find(filterElement).show().filter(function () {
+                //dont hide selected values
+                if ($(this).find('input').is(":checked")) {
+                    counter++;
+                    return false;
+                }
+                console.log($(this).find('input').val());
+                return $(this).find('input').val().toLowerCase().trim().indexOf(value) == -1;
+            }).hide();
+
+            if(defaultVisibleItems < items.find(filterElement +':visible').length) {
+                //more items visible then max visible items set on filter
+                items.find(filterElement + ':visible').show().filter(function () {
+                    if ((counter) > defaultVisibleItems) {
+                        return true;
+                    }
+                    counter++;
+                    return false;
+                }).hide();
+            }
+
+            //no items found
+            if (items.find(filterElement + ':visible').length < 1) {
+                noItems.show();
+            } else {
+                noItems.hide();
+            }
+
+
+            //hide show more/less button
+            if (value.length == 0) {
+                filterInput.parent('div').find('.more-items').show();
+            } else {
+                filterInput.parent('div').find('.more-items').hide();
+                filterInput.parent('div').find('.less-items').hide();
+            }
         },
     });
 


### PR DESCRIPTION
When the filtersearch option is enabled within Tweakwise for a specific filter in the filter template, a search box will now appear above the filter. This search box allows users to conveniently search through the filter values associated with that particular filter.

In cases where no filters are found, the designated text for displaying no results as configured in Tweakwise will be shown.

Additionally, users have the option to specify placeholder text for the search box within Tweakwise.

These modifications have been implemented within the default filter view. If you have customized your own view, please ensure to incorporate these changes accordingly.