### PR TITLE
fix: Fix filter url without ajax

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -378,7 +378,11 @@ class PathSlugStrategy implements
             }
         } else {
             // Replace filter path in current URL with the new filter combination path
-            $url = str_replace($currentFilterPath, $newFilterPath, $currentUrl);
+            if (strpos($currentUrl, $currentFilterPath) !== false) {
+                $url = str_replace($currentFilterPath, $newFilterPath, $currentUrl);
+            } else {
+                $url = $currentUrl . '/' . $newFilterPath;
+            }
         }
         $categoryUrlSuffix = $this->scopeConfig->getValue(
             CategoryUrlPathGenerator::XML_PATH_CATEGORY_URL_SUFFIX,


### PR DESCRIPTION
This pull request addresses an issue where, with ajax filtering disabled and the URL strategy set to "path", users couldn't select more than one filter simultaneously.