### PR TITLE
fix: allow access control origin in facets/facetattributes request

### DIFF
--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -91,7 +91,11 @@ class FacetAttributes extends Action
         //prevent non sequential array keys. That causes json encode to act diffrently and creates objects instead of arrays
         $result = array_values($result);
 
+        //set access control headers, for when the admin is on another domain
+        $json->setHeader('Access-Control-Allow-Origin', '*');
+        $json->setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
         $json->setData(['data' => $result]);
+
         return $json;
     }
 }

--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -88,12 +88,15 @@ class FacetAttributes extends Action
 
         $result = array_unique($result, SORT_REGULAR);
 
-        //prevent non sequential array keys. That causes json encode to act diffrently and creates objects instead of arrays
+        //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
         $result = array_values($result);
 
         //set access control headers, for when the admin is on another domain
         $json->setHeader('Access-Control-Allow-Origin', '*');
-        $json->setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
+        $json->setHeader(
+            'Access-Control-Allow-Headers',
+            'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+        );
         $json->setData(['data' => $result]);
 
         return $json;

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -80,7 +80,10 @@ class Facets extends Action
 
         //set access control headers, for when the admin is on another domain
         $json->setHeader('Access-Control-Allow-Origin', '*');
-        $json->setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
+        $json->setHeader(
+            'Access-Control-Allow-Headers',
+            'Content-Type, Access-Control-Allow-Headers,Authorization, X-Requested-With'
+        );
         $json->setData(['data' => $result]);
 
         return $json;

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -78,7 +78,11 @@ class Facets extends Action
         //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
         $result = array_values($result);
 
+        //set access control headers, for when the admin is on another domain
+        $json->setHeader('Access-Control-Allow-Origin', '*');
+        $json->setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
         $json->setData(['data' => $result]);
+
         return $json;
     }
 }


### PR DESCRIPTION
When the admin runs on an different domein, the facet/facetattributes request fail due to access control limitations. This pull request fixes that by setting the access control allow origin in the headers.