### PR TITLE
fix: remove duplicate facet keys

### DIFF
--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -86,7 +86,12 @@ class FacetAttributes extends Action
 
         $result[] = ['value' => 'tw_other', 'label' => 'Other (text field)'];
 
-        $result = array_unique($result, SORT_REGULAR);
+        //prevent duplicate keys
+        $values = array_column($result, 'value');
+        $uniqueValues = array_unique($values);
+        $uniqueKeys = array_keys($uniqueValues);
+        $result = array_intersect_key($result, array_flip($uniqueKeys));
+
 
         //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
         $result = array_values($result);

--- a/Controller/Ajax/FacetAttributes.php
+++ b/Controller/Ajax/FacetAttributes.php
@@ -92,7 +92,6 @@ class FacetAttributes extends Action
         $uniqueKeys = array_keys($uniqueValues);
         $result = array_intersect_key($result, array_flip($uniqueKeys));
 
-
         //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
         $result = array_values($result);
 

--- a/Controller/Ajax/Facets.php
+++ b/Controller/Ajax/Facets.php
@@ -73,7 +73,11 @@ class Facets extends Action
 
         $result[] = ['value' => 'tw_other', 'label' => 'Other (text field)'];
 
-        $result = array_unique($result, SORT_REGULAR);
+        //prevent duplicate keys
+        $values = array_column($result, 'value');
+        $uniqueValues = array_unique($values);
+        $uniqueKeys = array_keys($uniqueValues);
+        $result = array_intersect_key($result, array_flip($uniqueKeys));
 
         //prevent non sequential array keys. That causes json encode to act differently and creates objects instead of arrays
         $result = array_values($result);


### PR DESCRIPTION
Fixes https://github.com/EmicoEcommerce/Magento2AttributeLandingTweakwise/issues/30

Remove duplicate keys from facet lists. Even if they have an different label. (different languages) The url key is the same. So it doesn't need to be an duplicate facet.