### PR TITLE
fix: case insensitive attribute slugs

### DIFF
--- a/Model/AttributeSlug.php
+++ b/Model/AttributeSlug.php
@@ -32,7 +32,7 @@ class AttributeSlug extends AbstractModel implements AttributeSlugInterface
      */
     public function getAttribute(): ?string
     {
-        return $this->getData(self::ATTRIBUTE);
+        return strtolower($this->getData(self::ATTRIBUTE));
     }
 
     /**

--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -81,7 +81,7 @@ class FilterSlugManager
     public function getSlugForFilterItem(Item $filterItem): string
     {
         $lookupTable = $this->getLookupTable();
-        $attribute = $filterItem->getAttribute()->getTitle();
+        $attribute = strtolower($filterItem->getAttribute()->getTitle());
 
         if (isset($lookupTable[$attribute])) {
             return $lookupTable[$attribute];


### PR DESCRIPTION
When you have an attribute (Green) with an uppercase. And an attribute with an lowercase it's possible that the slug cannot be found, and you get an wrong slug url. Tweakwise itself is case insensitive for filters, but the tweakwise slug table in magento isn't.

For example:

- You have an tweakwise response with the color attribute, with the color: green (lowercase)
- You have an color attribute in magento with the color green. (with an dot in the name). The slug is then 'green' without the dot.
- And you have an color Green als color attribute in magento. This has the slug green-1 in the slug table.

In this case you request an slug for the attribute 'green' and you get nothing (since only green. and Green are available). So no slug is available and the attribute name 'green' is used as an slug.
When this slug is translated back to an value for tweakwise you get green. since this has the corresponding slug and not Green.

This pull request fixes that and returns green-1 for the attribute green. And translates it back to Green for TW (TW is case insensitive).