### PR TITLE
fix: case insensitive-attributes

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -132,7 +132,7 @@ class FilterSlugManager
      */
     public function getAttributeBySlug(string $slug): string
     {
-        $attribute = array_search($slug, $this->getLookupTable(), true);
+        $attribute = array_search($slug, $this->getLookupTable(), false);
         if ($attribute === false) {
             // Check if slug matched the pattern for a slider filter (i.e. 80-120).
             if (preg_match('/^\d+-\d+$/', $slug)) {


### PR DESCRIPTION
If you have the attribute Black in the tweakwise_attribute_slug_table with the value slug value black-1. And tweakwise sends the color 'black'. The correct slug is not found. It should return black-1. But you get black because the attribute could not be found. In most cases this causes no problem but if the slug 'black' already exists it translates back to the wrong value for TW.

In this fix we make sure an slug is found for Black regardless of the case. 