### PR TITLE
fix: trim attribute value with space

### DIFF
--- a/Model/Client/Request/ProductNavigationRequest.php
+++ b/Model/Client/Request/ProductNavigationRequest.php
@@ -50,7 +50,7 @@ class ProductNavigationRequest extends Request
      */
     public function addAttributeFilter(string $attribute, $value)
     {
-        $this->addParameter('tn_fk_' . $attribute, $value);
+        $this->addParameter('tn_fk_' . $attribute, trim($value));
         return $this;
     }
 


### PR DESCRIPTION
When you have an attribute value with an trailing space. The filter selecting doesn't work properly with the slug url strategy. The selected filter is not shown by the selected filters.

This pull requests fixes that by removing the spaces