### PR TITLE
fix:show no results when filter combination returns no products

### DIFF
--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -109,8 +109,10 @@ class Request
             if ($value == null) {
                 unset($this->parameters[$parameter]);
             } else {
-                if ((!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) &&
-                    ($this->parameters[$parameter] !== $value)) {
+                if (
+                    (!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) &&
+                    ($this->parameters[$parameter] !== $value)
+                ) {
                     $this->parameters[$parameter] = $this->parameters[$parameter] . $separator . $value;
                 }
             }

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -109,7 +109,7 @@ class Request
             if ($value == null) {
                 unset($this->parameters[$parameter]);
             } else {
-                if (!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) {
+                if ((!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) && ($this->parameters[$parameter] !== $value)) {
                     $this->parameters[$parameter] = $this->parameters[$parameter] . $separator . $value;
                 }
             }

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -109,7 +109,8 @@ class Request
             if ($value == null) {
                 unset($this->parameters[$parameter]);
             } else {
-                if ((!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) && ($this->parameters[$parameter] !== $value)) {
+                if ((!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) &&
+                    ($this->parameters[$parameter] !== $value)) {
                     $this->parameters[$parameter] = $this->parameters[$parameter] . $separator . $value;
                 }
             }


### PR DESCRIPTION
When you select an filter combination (for example price 49-50) that returns no results. All results are shown instead of no results.

This is because the system tries to reset the pagination and see if that returns an result. But this caused the filter selection to be invalid and all products where shown.