### PR TITLE
fix: Check if attribute exists case insensitive

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -112,7 +112,7 @@ class FilterSlugManager
             }
 
             $this->getLookupTable();
-            if (isset($this->lookupTable[$option->getLabel()])) {
+            if (isset($this->lookupTable[strtolower($option->getLabel())])) {
                 continue;
             }
 


### PR DESCRIPTION
Check if attribute exists lowercase since attributes are saved lowercase now.