### PR TITLE
Feat add subtype suggestions

### DIFF
--- a/Model/Autocomplete/DataProvider/SuggestionGroupItem.php
+++ b/Model/Autocomplete/DataProvider/SuggestionGroupItem.php
@@ -36,7 +36,8 @@ class SuggestionGroupItem implements ItemInterface
     {
         $result = [
             'type' => 'suggestion_group',
-            'title' => $this->group->getName()
+            'title' => $this->group->getName(),
+            'subtype' => $this->group->getType(),
         ];
         foreach ($this->group->getSuggestions() as $suggestion) {
             $suggestionUrl = $suggestion->getUrl();

--- a/Model/Client/Type/SuggestionTypeGroup.php
+++ b/Model/Client/Type/SuggestionTypeGroup.php
@@ -46,6 +46,14 @@ class SuggestionTypeGroup extends Type
     }
 
     /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
      * @param SuggestionTypeAbstract[]|array[] $suggestions
      * @return $this
      */


### PR DESCRIPTION
Added subtype to suggestions response.

The tweakwise type is returned as subtype. So you can see what an search-phrase or category is. This is added as subtype because of backward compatibility since the type is already used.
