### PR TITLE
Fix query parameter page sorting

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -161,10 +161,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
     {
         $selectedFilters = $request->getQuery();
         $reservedParams = [
-            self::PARAM_LIMIT,
-            self::PARAM_MODE,
             self::PARAM_PAGE,
-            self::PARAM_ORDER,
             self::PARAM_CATEGORY,
         ];
 


### PR DESCRIPTION
With ajax disabled en query parameter stategy enabled. The page sorting / mode and limit is not remembered when you select an filter. This pull request fixes that