### PR TITLE
fix: wrong product tiles

### DIFF
--- a/ViewModel/LinkedProductListItem.php
+++ b/ViewModel/LinkedProductListItem.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Tweakwise\Magento2Tweakwise\ViewModel;
 
 use Magento\Catalog\Model\Product;
+use Magento\Customer\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Framework\View\LayoutInterface;
 use Tweakwise\Magento2Tweakwise\Helper\Cache;
+use Magento\Store\Model\StoreManagerInterface;
 
 class LinkedProductListItem implements ArgumentInterface
 {
@@ -20,7 +22,9 @@ class LinkedProductListItem implements ArgumentInterface
      */
     public function __construct(
         private readonly LayoutInterface $layout,
-        private readonly Cache $cacheHelper
+        private readonly Cache $cacheHelper,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly Session $customerSession
     ) {
     }
 
@@ -59,10 +63,15 @@ class LinkedProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId, $cardType);
         }
 
+        $storeId = $this->storeManager->getStore()->getId();
+        $customerGroupId = $this->customerSession->getCustomerGroupId();
+
         return sprintf(
-            '<esi:include src="/%s?product_id=%s&card_type=%s" />',
+            '<esi:include src="/%s?product_id=%s&store_id=%s&customer_group_id=%s&card_type=%s" />',
             Cache::PRODUCT_CARD_PATH,
             $productId,
+            $storeId,
+            $customerGroupId,
             $cardType
         );
     }

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -11,6 +11,7 @@ use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Framework\View\LayoutInterface;
 use Tweakwise\Magento2Tweakwise\Helper\Cache;
+use Magento\Store\Model\StoreManagerInterface;
 
 class ProductListItem implements ArgumentInterface
 {
@@ -20,7 +21,8 @@ class ProductListItem implements ArgumentInterface
      */
     public function __construct(
         private readonly LayoutInterface $layout,
-        private readonly Cache $cacheHelper
+        private readonly Cache $cacheHelper,
+        private readonly StoreManagerInterface $storeManager
     ) {
     }
 
@@ -58,6 +60,7 @@ class ProductListItem implements ArgumentInterface
         }
 
         $productId = (int) $product->getId();
+        $storeId = $this->storeManager->getStore()->getId();
         if (!$this->cacheHelper->load($productId)) {
             $itemHtml = $this->getItemHtmlWithRenderer(
                 $product,
@@ -70,7 +73,8 @@ class ProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId);
         }
 
-        return sprintf('<esi:include src="/%s?product_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId);
+        //return sprintf('<esi:include src="/%s?product_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId);
+        return sprintf('<esi:include src="/%s?product_id=%s&store_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId, $storeId);
     }
 
     /**

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -73,8 +73,10 @@ class ProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId);
         }
 
-        return sprintf('<esi:include src="/%s?product_id=%s&store_id=%s" />',
-            Cache::PRODUCT_CARD_PATH, $productId, $storeId);
+        return sprintf(
+            '<esi:include src="/%s?product_id=%s&store_id=%s" />',
+            Cache::PRODUCT_CARD_PATH, $productId, $storeId
+        );
     }
 
     /**

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tweakwise\Magento2Tweakwise\ViewModel;
 
 use Magento\Catalog\Model\Product;
+use Magento\Customer\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\AbstractBlock;
@@ -22,7 +23,8 @@ class ProductListItem implements ArgumentInterface
     public function __construct(
         private readonly LayoutInterface $layout,
         private readonly Cache $cacheHelper,
-        private readonly StoreManagerInterface $storeManager
+        private readonly StoreManagerInterface $storeManager,
+        private readonly Session $customerSession
     ) {
     }
 
@@ -60,7 +62,7 @@ class ProductListItem implements ArgumentInterface
         }
 
         $productId = (int) $product->getId();
-        $storeId = $this->storeManager->getStore()->getId();
+
         if (!$this->cacheHelper->load($productId)) {
             $itemHtml = $this->getItemHtmlWithRenderer(
                 $product,
@@ -73,11 +75,15 @@ class ProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId);
         }
 
+        $storeId = $this->storeManager->getStore()->getId();
+        $customerGroupId = $this->customerSession->getCustomerGroupId();
+
         return sprintf(
-            '<esi:include src="/%s?product_id=%s&store_id=%s" />',
+            '<esi:include src="/%s?product_id=%s&store_id=%s&customer_group_id=%s&cardtype=default" />',
             Cache::PRODUCT_CARD_PATH,
             $productId,
-            $storeId
+            $storeId,
+            $customerGroupId
         );
     }
 

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -73,7 +73,8 @@ class ProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId);
         }
 
-        return sprintf('<esi:include src="/%s?product_id=%s&store_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId, $storeId);
+        return sprintf('<esi:include src="/%s?product_id=%s&store_id=%s" />',
+            Cache::PRODUCT_CARD_PATH, $productId, $storeId);
     }
 
     /**

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -75,7 +75,9 @@ class ProductListItem implements ArgumentInterface
 
         return sprintf(
             '<esi:include src="/%s?product_id=%s&store_id=%s" />',
-            Cache::PRODUCT_CARD_PATH, $productId, $storeId
+            Cache::PRODUCT_CARD_PATH,
+            $productId,
+            $storeId
         );
     }
 

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -79,7 +79,7 @@ class ProductListItem implements ArgumentInterface
         $customerGroupId = $this->customerSession->getCustomerGroupId();
 
         return sprintf(
-            '<esi:include src="/%s?product_id=%s&store_id=%s&customer_group_id=%s&cardtype=default" />',
+            '<esi:include src="/%s?product_id=%s&store_id=%s&customer_group_id=%s" />',
             Cache::PRODUCT_CARD_PATH,
             $productId,
             $storeId,

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -73,7 +73,6 @@ class ProductListItem implements ArgumentInterface
             $this->cacheHelper->save($itemHtml, $productId);
         }
 
-        //return sprintf('<esi:include src="/%s?product_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId);
         return sprintf('<esi:include src="/%s?product_id=%s&store_id=%s" />', Cache::PRODUCT_CARD_PATH, $productId, $storeId);
     }
 


### PR DESCRIPTION
With the merchandising builder enabled. It is possible to get an wrong product tile in an wrong language form an different storeview. 

This pull request fixes that by adding an store id to the esi request.