### PR TITLE
fix: bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "OSL-3.0",
     "description": "Magento 2 module for Tweakwise integration",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-pcre": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
Bump minimum php version to 8.1. Php 8.1 is needed since the recommendation changes, but it wasn't updated in the composer.json.