### PR TITLE
fix: change cron group

### DIFF
--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -8,7 +8,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="tweakwise">
         <job name="Tweakwise_Magento2Tweakwise_version" instance="Tweakwise\Magento2Tweakwise\Cron\Version" method="execute">
             <!-- once every day at midnight-->
             <schedule>0 0 * * *</schedule>


### PR DESCRIPTION
Change the crongroup from the default group to prevent blocking magento crons.