### PR TITLE
fix: price slider

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/SliderRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/SliderRenderer.php
@@ -128,7 +128,7 @@ class SliderRenderer extends DefaultRenderer
             return $value;
         }
 
-        return $this->priceHelper->currency($value);
+        return $this->priceHelper->currency($value, true, false);
     }
 
     /**


### PR DESCRIPTION
If the price slider is escaped in the phtml template, you get an <span> class shown as text because the price span is added automatically. That is not needed here.