### PR TITLE
Fix: urlencode filter

### DIFF
--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -126,7 +126,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'productListSelector' => '.products.wrapper',
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
-                'urlStrategy' => $this->config->getUrlStrategy()
+                'urlStrategy' => $this->config->getUrlStrategy() === 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy' ? 'queryparameter' : 'path',
             ],
         ];
         if ($this->config->isPersonalMerchandisingActive()) {

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -23,7 +23,7 @@ use Tweakwise\Magento2Tweakwise\Model\FilterFormInputProvider\HashInputProvider;
  */
 class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInterface
 {
-    const QUERY_PARAMETER_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
+    private const QUERY_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
 
     /**
      * @var Config
@@ -129,7 +129,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
                 'urlStrategy' => $this->config->getUrlStrategy() ===
-                self::QUERY_PARAMETER_STRATEGY
+                self::QUERY_STRATEGY
                     ? 'queryparameter'
                     : 'path',
             ],

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -23,7 +23,7 @@ use Tweakwise\Magento2Tweakwise\Model\FilterFormInputProvider\HashInputProvider;
  */
 class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInterface
 {
-    private const QUERY_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
+    private const URL_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
 
     /**
      * @var Config
@@ -129,7 +129,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
                 'urlStrategy' => $this->config->getUrlStrategy() ===
-                self::QUERY_STRATEGY
+                self::URL_STRATEGY
                     ? 'queryparameter'
                     : 'path',
             ],

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -23,8 +23,6 @@ use Tweakwise\Magento2Tweakwise\Model\FilterFormInputProvider\HashInputProvider;
  */
 class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInterface
 {
-    private const URL_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
-
     /**
      * @var Config
      */

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -129,7 +129,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
                 'urlStrategy' => $this->config->getUrlStrategy() ===
-                self::URL_STRATEGY
+                QueryParameterStrategy::class
                     ? 'queryparameter'
                     : 'path',
             ],

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -23,6 +23,8 @@ use Tweakwise\Magento2Tweakwise\Model\FilterFormInputProvider\HashInputProvider;
  */
 class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInterface
 {
+    const QUERY_PARAMETER_STRATEGY = 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy';
+
     /**
      * @var Config
      */
@@ -126,7 +128,10 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'productListSelector' => '.products.wrapper',
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
-                'urlStrategy' => $this->config->getUrlStrategy() === 'Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy' ? 'queryparameter' : 'path',
+                'urlStrategy' => $this->config->getUrlStrategy() ===
+                self::QUERY_PARAMETER_STRATEGY
+                    ? 'queryparameter'
+                    : 'path',
             ],
         ];
         if ($this->config->isPersonalMerchandisingActive()) {

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -126,6 +126,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                 'productListSelector' => '.products.wrapper',
                 'toolbarSelector' => '.toolbar.toolbar-products',
                 'ajaxCache' => true,
+                'urlStrategy' => $this->config->getUrlStrategy()
             ],
         ];
         if ($this->config->isPersonalMerchandisingActive()) {

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -184,7 +184,7 @@ define([
                 href = seoHref ? seoHref : href;
             }
 
-            if (this.options.urlStrategy === 'Tweakwise\\Magento2Tweakwise\\Model\\Catalog\\Layer\\Url\\Strategy\\QueryParameterStrategy') {
+            if (this.options.urlStrategy === 'queryparameter') {
                 let url = new URL(href, window.location.origin);
                 url.search = this._getFilterParameters();
                 return url.toString();

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -26,6 +26,7 @@ define([
             noticeMessageSelector: '.message.notice',
             isLoading: false,
             ajaxCache: true,
+            urlStrategy: '',
         },
 
         currentXhr: null,
@@ -183,10 +184,13 @@ define([
                 href = seoHref ? seoHref : href;
             }
 
-            let url = new URL(href, window.location.origin);
-            url.search = this._getFilterParameters();
+            if (this.options.urlStrategy === 'Tweakwise\\Magento2Tweakwise\\Model\\Catalog\\Layer\\Url\\Strategy\\QueryParameterStrategy') {
+                let url = new URL(href, window.location.origin);
+                url.search = this._getFilterParameters();
+                return url.toString();
+            }
 
-            return url.toString();
+            return href;
         },
 
         /**


### PR DESCRIPTION
This fixes #228. The solution caused the query string to also be present when using the url path strategy. This pull requests makes sure that the fix only is used when you have the url query parameter stategy enabled.