### PR TITLE
fix: analytics checkout

### DIFF
--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -38,7 +38,7 @@ class Analytics extends Action
     /**
      * @return ResponseInterface|Json|ResultInterface
      */
-    public function execute()
+    public function execute(): ResponseInterface|Json|ResultInterface
     {
         $result = $this->resultJsonFactory->create();
         if ($this->config->isAnalyticsEnabled()) {

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -330,7 +330,7 @@ class Request
     /**
      * @return string|null
      */
-    public function setParameterArray(string $parameter, array $value)
+    public function setParameterArray(string $parameter, array $value): Request
     {
         $this->parameters[$parameter] = $value;
         return $this;
@@ -339,7 +339,7 @@ class Request
     /**
      * @return string|null
      */
-    public function isPostRequest()
+    public function isPostRequest(): bool
     {
         return false;
     }

--- a/Model/Client/Request/AnalyticsRequest.php
+++ b/Model/Client/Request/AnalyticsRequest.php
@@ -24,7 +24,7 @@ class AnalyticsRequest extends Request
     /**
      * @return string
      */
-    public function isPostRequest()
+    public function isPostRequest(): bool
     {
         return true;
     }
@@ -32,7 +32,7 @@ class AnalyticsRequest extends Request
     /**
      * @return string
      */
-    public function getApiurl()
+    public function getApiurl(): string
     {
         return $this->apiUrl;
     }
@@ -40,7 +40,7 @@ class AnalyticsRequest extends Request
     /**
      * @return void
      */
-    public function setProfileKey(string $profileKey)
+    public function setProfileKey(string $profileKey): void
     {
         $this->setParameter('ProfileKey', $profileKey);
     }
@@ -48,7 +48,7 @@ class AnalyticsRequest extends Request
     /**
      * @return void
      */
-    public function setPath($path)
+    public function setPath($path): void
     {
         $this->path = $path;
     }
@@ -56,7 +56,7 @@ class AnalyticsRequest extends Request
     /**
      * @return string
      */
-    public function getProfileKey()
+    public function getProfileKey(): string
     {
         $profileKey = $this->getCookie($this->config->getPersonalMerchandisingCookieName());
         if (!$profileKey) {

--- a/Model/Client/Request/PurchaseRequest.php
+++ b/Model/Client/Request/PurchaseRequest.php
@@ -29,7 +29,7 @@ class PurchaseRequest extends Request
     /**
      * @return true
      */
-    public function isPostRequest()
+    public function isPostRequest(): bool
     {
         return true;
     }
@@ -37,7 +37,7 @@ class PurchaseRequest extends Request
     /**
      * @return mixed|string
      */
-    public function getApiurl()
+    public function getApiurl(): string
     {
         return $this->apiUrl;
     }
@@ -47,7 +47,7 @@ class PurchaseRequest extends Request
      *
      * @return void
      */
-    public function setProfileKey(string $profileKey)
+    public function setProfileKey(string $profileKey): void
     {
         $this->setParameter('ProfileKey', $profileKey);
     }

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -31,7 +31,7 @@ class PersonalMerchandisingConfig extends Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAnalyticsEnabled(Store $store = null)
+    public function isAnalyticsEnabled(Store $store = null): bool
     {
         return (bool)$this->getStoreConfig('tweakwise/personal_merchandising/analytics_enabled', $store);
     }
@@ -39,7 +39,7 @@ class PersonalMerchandisingConfig extends Config
     /**
      * @return string|null
      */
-    public function getProfileKey()
+    public function getProfileKey(): ?string
     {
         $profileKey = $this->cookieManager->getCookie(
             $this->getPersonalMerchandisingCookieName(),
@@ -61,9 +61,9 @@ class PersonalMerchandisingConfig extends Config
     }
 
     /**
-     * @return string
+     * @return CookieMetadataInterface
      */
-    private function getCookieMetadata()
+    private function getCookieMetadata(): CookieMetadataInterface
     {
         return $this->cookieMetadataFactory
             ->createPublicCookieMetadata()
@@ -75,7 +75,7 @@ class PersonalMerchandisingConfig extends Config
     /**
      * @return string
      */
-    private function generateProfileKey()
+    private function generateProfileKey(): string
     {
         return uniqid('', true);
     }

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -43,9 +43,9 @@ class TweakwiseCheckout implements ObserverInterface
      * @return void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer) : void
     {
-        if ($this->config->isAnalyticsEnabled('tweakwise/personal_merchandising/analytics_enabled')) {
+        if ($this->config->isAnalyticsEnabled()) {
             $order = $observer->getEvent()->getOrder();
             // Get the order items
             $items = $order->getAllItems();
@@ -60,7 +60,7 @@ class TweakwiseCheckout implements ObserverInterface
      * @return void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    private function sendCheckout($items)
+    private function sendCheckout($items) : void
     {
         $storeId = (int)$this->storeManager->getStore()->getId();
         $profileKey = $this->config->getProfileKey();

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -43,7 +43,7 @@ class TweakwiseCheckout implements ObserverInterface
      * @return void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function execute(Observer $observer) : void
+    public function execute(Observer $observer): void
     {
         if ($this->config->isAnalyticsEnabled()) {
             $order = $observer->getEvent()->getOrder();
@@ -60,7 +60,7 @@ class TweakwiseCheckout implements ObserverInterface
      * @return void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    private function sendCheckout($items) : void
+    private function sendCheckout($items): void
     {
         $storeId = (int)$this->storeManager->getStore()->getId();
         $profileKey = $this->config->getProfileKey();


### PR DESCRIPTION
When tweakwise analytics is enabled it gives an error because an string is send instead of an store code.