### PR TITLE
fix-special-character-slug

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -84,7 +84,7 @@ class FilterSlugManager
         $lookupTable = $this->getLookupTable();
         $attribute = strtolower($filterItem->getAttribute()->getTitle());
 
-        if (isset($lookupTable[$attribute])) {
+        if (!empty($lookupTable[$attribute])) {
             return $lookupTable[$attribute];
         }
 
@@ -121,6 +121,10 @@ class FilterSlugManager
             $optionLabel = $option->getLabel();
             if ($optionLabel instanceof Phrase) {
                 $optionLabel = $optionLabel->render();
+            }
+
+            if (empty($this->translitUrl->filter($option->getLabel()))) {
+                continue;
             }
 
             if (isset($this->lookupTable[strtolower($option->getLabel())])) {


### PR DESCRIPTION
When you have an special character like $ als the slug without other characters. The slug can be empty when you use the following tweakwise settings. This causes the filter to not work

ajax filtering enabled
url path slug strategy
seo enabled

This pull request fixes that. If the url is empty. The original character is used as an slug.