### PR TITLE
fix: redirect to new category url

### DIFF
--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -74,12 +74,11 @@ class Router implements RouterInterface
             return $result;
         }
 
-        $url = $request->getParam('redirect');
+        $url = $request->getParam('tw_filter_redirect');
 
-        if($url) {
-            $url = $request->getParam('redirect');
+        if ($url) {
             $redirect = $this->actionFactory->create(Redirect::class);
-            $redirect->getResponse()->setRedirect($request->getParam('redirect'));
+            $redirect->getResponse()->setRedirect($url);
             return $redirect;
         }
 

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -9,6 +9,7 @@
 
 namespace Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy;
 
+use Magento\Framework\App\ResponseFactory;
 use Tweakwise\Magento2Tweakwise\Exception\RuntimeException;
 use Tweakwise\Magento2Tweakwise\Exception\UnexpectedValueException;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Filter\Item;
@@ -136,6 +137,7 @@ class PathSlugStrategy implements
         CurrentContext $currentContext,
         ScopeConfigInterface $scopeConfig,
         StrategyHelper $strategyHelper,
+        private ResponseFactory $responseFactory,
         array $rewriteResolvers,
         array $skipMatchExtensions
     ) {
@@ -516,6 +518,12 @@ class PathSlugStrategy implements
             for each filter. Meaning that a correct filter path should have an even number of path parts
             */
             return false;
+        }
+
+        if ($rewrite->getRedirectType() === 301) {
+            $url = $this->magentoUrl->getDirectUrl($rewrite->getTargetPath() . $filterPath);
+            $this->responseFactory->create()->setRedirect($url)->sendResponse();
+            exit;
         }
 
         // Set the filter params part of the URL as a separate request param.

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -520,7 +520,7 @@ class PathSlugStrategy implements
 
         if ($rewrite->getRedirectType() === 301) {
             $url = $this->magentoUrl->getDirectUrl($rewrite->getTargetPath() . $filterPath);
-            $request->setParam('redirect', $url);
+            $request->setParam('tw_filter_redirect', $url);
         }
 
         // Set the filter params part of the URL as a separate request param.

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -124,6 +124,7 @@ class PathSlugStrategy implements
      * @param CurrentContext $currentContext
      * @param ScopeConfigInterface $scopeConfig
      * @param StrategyHelper $strategyHelper
+     * @param ResponseFactory $responseFactory
      * @param RewriteResolverInterface[] $rewriteResolvers
      * @param array $skipMatchExtensions
      */
@@ -523,7 +524,7 @@ class PathSlugStrategy implements
         if ($rewrite->getRedirectType() === 301) {
             $url = $this->magentoUrl->getDirectUrl($rewrite->getTargetPath() . $filterPath);
             $this->responseFactory->create()->setRedirect($url)->sendResponse();
-            exit;
+            return false;
         }
 
         // Set the filter params part of the URL as a separate request param.

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -524,7 +524,7 @@ class PathSlugStrategy implements
         if ($rewrite->getRedirectType() === 301) {
             $url = $this->magentoUrl->getDirectUrl($rewrite->getTargetPath() . $filterPath);
             $this->responseFactory->create()->setRedirect($url)->sendResponse();
-            return false;
+            exit;
         }
 
         // Set the filter params part of the URL as a separate request param.

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -9,7 +9,6 @@
 
 namespace Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy;
 
-use Magento\Framework\App\ResponseFactory;
 use Tweakwise\Magento2Tweakwise\Exception\RuntimeException;
 use Tweakwise\Magento2Tweakwise\Exception\UnexpectedValueException;
 use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Filter\Item;
@@ -124,7 +123,6 @@ class PathSlugStrategy implements
      * @param CurrentContext $currentContext
      * @param ScopeConfigInterface $scopeConfig
      * @param StrategyHelper $strategyHelper
-     * @param ResponseFactory $responseFactory
      * @param RewriteResolverInterface[] $rewriteResolvers
      * @param array $skipMatchExtensions
      */
@@ -138,7 +136,6 @@ class PathSlugStrategy implements
         CurrentContext $currentContext,
         ScopeConfigInterface $scopeConfig,
         StrategyHelper $strategyHelper,
-        private ResponseFactory $responseFactory,
         array $rewriteResolvers,
         array $skipMatchExtensions
     ) {


### PR DESCRIPTION
When you use the path slug url strategy. And you change the url of an category. You don't get redirected to the new url

For exmaple

category/filter/value

doesn't get redirected to

newcategoryurl/filter/value

This pull request fixes that.