### PR TITLE
fix: search category view

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
@@ -140,9 +140,13 @@ class DefaultRenderer extends Template
      */
     private function findCurrentCategory($items)
     {
-        $storeId = $this->filter->getStoreId();
-        $currentCategory = $this->filter->getLayer()->getCurrentCategory();
-        $tweakwiseCategoryId = $this->helper->getTweakwiseId($storeId, $currentCategory->getId());
+        $tweakwiseCategoryId = $this->navigationConfig->getNavigationContext()->getContext()->getResponse()->getProperties()->getSelectedCategoryId();
+
+        if (empty($tweakwiseCategoryId)) {
+            $storeId = $this->filter->getStoreId();
+            $currentCategory = $this->filter->getLayer()->getCurrentCategory();
+            $tweakwiseCategoryId = $this->helper->getTweakwiseId($storeId, $currentCategory->getId());
+        }
 
         foreach ($items as $index => $item) {
             if ($item->getAttribute()->getValue('attributeid') == $tweakwiseCategoryId) {

--- a/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
@@ -140,7 +140,13 @@ class DefaultRenderer extends Template
      */
     private function findCurrentCategory($items)
     {
-        $tweakwiseCategoryId = $this->navigationConfig->getNavigationContext()->getContext()->getResponse()->getProperties()->getSelectedCategoryId();
+        $tweakwiseCategoryId = $this
+                ->navigationConfig
+                ->getNavigationContext()
+                ->getContext()
+                ->getResponse()
+                ->getProperties()
+                ->getSelectedCategoryId();
 
         if (empty($tweakwiseCategoryId)) {
             $storeId = $this->filter->getStoreId();


### PR DESCRIPTION
When you have the following settings enabled and see an category view in the search results. The results are not the same as the tweakwise demoshop when you select an subcategory

- Have the magento tweakwise setting for category view on extended
- Have an category view in you tweakwise filters set to link in tweakwise itself.

This pull request fixes that by setting the current category based on what tweakwise says it's the active category. So that in the search results the correct sub categories are shown, and not those of the parent.