### PR TITLE
fix: Show visuals without merchandising builder and AJAX filtering enabled

### DIFF
--- a/Block/Product/ListProduct.php
+++ b/Block/Product/ListProduct.php
@@ -117,10 +117,7 @@ class ListProduct extends MagentoListProduct
      */
     public function getTemplate()
     {
-        if (
-            !$this->cacheHelper->personalMerchandisingCanBeApplied() ||
-            $this->cacheHelper->isHyvaTheme()
-        ) {
+        if ($this->cacheHelper->isHyvaTheme()) {
             return parent::getTemplate();
         }
 

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -167,10 +167,7 @@ class Collection extends AbstractCollection
         parent::_afterLoad();
 
         $this->applyCollectionSizeValues();
-
-        if ($this->config->isPersonalMerchandisingActive()) {
-            $this->addVisuals();
-        }
+        $this->addVisuals();
 
         return $this;
     }

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -31,12 +31,10 @@
             </arguments>
             <block class="Magento\Catalog\Block\Product\AbstractProduct"
                    name="tweakwise.catalog.product.list.item"
-                   template="Tweakwise_Magento2Tweakwise::product/list/item.phtml"
-                   ifconfig="tweakwise/personal_merchandising/enabled"/>
+                   template="Tweakwise_Magento2Tweakwise::product/list/item.phtml"/>
             <block class="Magento\Catalog\Block\Product\AbstractProduct"
                    name="tweakwise.catalog.product.list.visual"
-                   template="Tweakwise_Magento2Tweakwise::product/list/visual.phtml"
-                   ifconfig="tweakwise/personal_merchandising/enabled"/>
+                   template="Tweakwise_Magento2Tweakwise::product/list/visual.phtml"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
With this fix it is possible to show visuals without Merchandising and AJAX filtering enabled