### PR TITLE
fix: return type

### DIFF
--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -38,7 +38,7 @@ class Analytics extends Action
     /**
      * @return ResponseInterface|Json|ResultInterface
      */
-    public function execute(): ResponseInterface|Json|ResultInterface
+    public function execute()
     {
         $result = $this->resultJsonFactory->create();
         if ($this->config->isAnalyticsEnabled()) {


### PR DESCRIPTION
Removed return type to fix #250 

It implements the ActionInterface though an parent class. And the execute function doesn't have return a type.