### PR TITLE
fix: wrong class check

### DIFF
--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -12,6 +12,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Tweakwise\Magento2Tweakwise\Model\FilterFormInputProvider\HashInputProvider;
+use Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy;
 
 /**
  * Class NavigationConfig


### PR DESCRIPTION
The fix in #232 checked te wrong class. So the & sign was not properly encoded when using the queryparameter url strategy