### PR TITLE
fix: Fixed issue on catalog search page when Merchandising Builder was disabled

### DIFF
--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -34,13 +34,6 @@
                 </arguments>
             </block>
         </referenceBlock>
-        <referenceBlock name="search_result_list">
-            <arguments>
-                <argument name="view_model_product_list_item" xsi:type="object">
-                    Tweakwise\Magento2Tweakwise\ViewModel\ProductListItem
-                </argument>
-            </arguments>
-        </referenceBlock>
         <referenceBlock name="catalogsearch.leftnav">
             <arguments>
                 <argument name="tweakwise_navigation_config" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\NavigationConfig\Search</argument>
@@ -54,8 +47,7 @@
             </arguments>
             <block class="Magento\Catalog\Block\Product\AbstractProduct"
                    name="tweakwise.catalog.product.list.item"
-                   template="Tweakwise_Magento2Tweakwise::product/list/item.phtml"
-                   ifconfig="tweakwise/personal_merchandising/enabled"/>
+                   template="Tweakwise_Magento2Tweakwise::product/list/item.phtml"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
**Description:**
There was a bug in showing the products in the catalog search when the merchandising builder was disabled. There was also a double referenceBlock in the XML layout which is removed now. The bug was caused by forgetting to remove the configuration check in the catalogsearch_result_index.xml in [this PR](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/254/files).

**Steps to reproduce bug:**

1. Set `Stores -> Configuration -> Catalog -> Tweakwise -> Merchandising Builder -> Enabled` configuration to `No`
2. Search for `bag` in the frontend
3. No products are displayed

After applying this bugfix the products are shown in the catalog search