### PR TITLE
fix: type error

### DIFF
--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -60,10 +60,10 @@ class PersonalMerchandisingConfig extends Config
         return $profileKey;
     }
 
-    /**
-     * @return CookieMetadataInterface
+P    /**
+     * @return PublicCookieMetadata
      */
-    private function getCookieMetadata(): CookieMetadataInterface
+    private function getCookieMetadata(): PublicCookieMetadata
     {
         return $this->cookieMetadataFactory
             ->createPublicCookieMetadata()

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -32,6 +32,7 @@ class PersonalMerchandisingConfig extends Config
     /**
      * @param Store|null $store
      * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function isAnalyticsEnabled(Store $store = null): bool
     {

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -11,6 +11,8 @@ use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Tweakwise\Magento2Tweakwise\Model\Config;
+use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
+use Magento\Store\Model\Store;
 
 class PersonalMerchandisingConfig extends Config
 {
@@ -21,8 +23,8 @@ class PersonalMerchandisingConfig extends Config
         State $state,
         WriterInterface $configWriter,
         TypeListInterface $cacheTypeList,
-        private CookieManagerInterface $cookieManager,
-        private CookieMetadataFactory $cookieMetadataFactory
+        private readonly CookieManagerInterface $cookieManager,
+        private readonly CookieMetadataFactory $cookieMetadataFactory
     ) {
         parent::__construct($config, $jsonSerializer, $request, $state, $configWriter, $cacheTypeList);
     }

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -13,6 +13,7 @@ use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
 use Magento\Store\Model\Store;
+use Magento\Framework\Exception\LocalizedException;
 
 class PersonalMerchandisingConfig extends Config
 {
@@ -32,7 +33,7 @@ class PersonalMerchandisingConfig extends Config
     /**
      * @param Store|null $store
      * @return bool
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function isAnalyticsEnabled(Store $store = null): bool
     {

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -60,9 +60,9 @@ class PersonalMerchandisingConfig extends Config
         return $profileKey;
     }
 
-P    /**
-     * @return PublicCookieMetadata
-     */
+   /**
+    * @return PublicCookieMetadata
+    */
     private function getCookieMetadata(): PublicCookieMetadata
     {
         return $this->cookieMetadataFactory


### PR DESCRIPTION
With the setting '**Send analytics events to tweakwise**' enabled the checkout gives an error: 

TypeError: Tweakwise\Magento2Tweakwise\Model\PersonalMerchandisingConfig::getCookieMetadata(): Return value must be of type Tweakwise\Magento2Tweakwise\Model\CookieMetadataInterface, Magento\Framework\Stdlib\Cookie\PublicCookieMetadata returned in vendor/tweakwise/magento2-tweakwise/Model/PersonalMerchandisingConfig.php:72

This pull request fixes that.

@jansentjeu Can you test if you can checkout without problems if the setting is enabled? I currently have some problems with my payment methods and it doesn't let me do an checkout.