### PR TITLE
Fix: bug pagination alp

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -301,10 +301,11 @@ class PathSlugStrategy implements
 
             if (
                 $page &&
-                (int) $page > 1 &&
-                count($this->getActiveFilters()) < 1
+                (int) $page > 1
             ) {
                 $query['p'] = $page;
+            } else {
+                unset($query['p']);
             }
 
             if ($sort) {

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -394,6 +394,11 @@ define([
             const baseUrl = window.location.origin;
             const resultUrl = new URL(response.url, baseUrl);
             const queryParams = new URLSearchParams(window.location.search ?? '');
+
+            if (!resultUrl.searchParams.has('p')) {
+                queryParams.delete('p');
+            }
+
             let queryParamsString = queryParams.toString();
 
             if (resultUrl.search) {


### PR DESCRIPTION
With ajax navigation and path slug url strategy enabled. The pagination number in the url on ALP's doesn't get updated properly. If you navigate to page 2 and then back to page 1. The url still shows page 2. This only happens on ALP's. This pull request fixes that.