### PR TITLE
fix: return-null-value

### DIFF
--- a/Model/Catalog/Layer/NavigationContext.php
+++ b/Model/Catalog/Layer/NavigationContext.php
@@ -148,11 +148,11 @@ class NavigationContext
     }
 
     /**
-     * @return ProductNavigationResponse|null
+     * @return ProductNavigationResponse
      * @throws Exception
      * @throws ApiException
      */
-    public function getResponse(): ProductNavigationResponse|null
+    public function getResponse(): ProductNavigationResponse
     {
         if (!$this->response) {
             $request = $this->getRequest();
@@ -166,6 +166,8 @@ class NavigationContext
                     //no api response
                     throw $e;
                 }
+            } else {
+                throw new ApiException('Tweakwise API is not reachable');
             }
         }
 

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -331,9 +331,9 @@ class Client
         try {
             return $this->doRequest($request, $async);
         } catch (ApiException $e) {
-            $this->config->setTweakwiseExceptionThrown(true);
             //don't log 404 messages.
             if ($e->getCode() !== 404) {
+                $this->config->setTweakwiseExceptionThrown(true);
                 $this->log->throwException($e);
             } else {
                 throw ($e);


### PR DESCRIPTION
This fixes #202 

Instead of checking everywhere if the value is null. The value should never be null. The value could only be null if an previous call to tweakwise failed.

I've changed two things to prevent null from being returned.

- Changed that an 404 request is seen as an tweakwise exception. This occurs when you're requesting recommendations for an product that is no longer available in TW.
- Changed that if there previous was an connection issue. An api exception is thrown. This causes magento to fallback to default functionality instead of an empty result. 