### PR TITLE
Fix: filter clear url

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -395,7 +395,8 @@ class PathSlugStrategy implements
         } else {
             // Replace filter path in current URL with the new filter combination path
             if (strpos($currentUrl, $currentFilterPath) !== false) {
-                $url = str_replace($currentFilterPath, $newFilterPath, $currentUrl);
+                rtrim($currentFilterPath, '/');
+                $url = str_replace($currentFilterPath.'/', $newFilterPath.'/', $currentUrl);
             } else {
                 $url = $currentUrl . '/' . $newFilterPath;
             }

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -395,8 +395,11 @@ class PathSlugStrategy implements
         } else {
             // Replace filter path in current URL with the new filter combination path
             if (strpos($currentUrl, $currentFilterPath) !== false) {
-                rtrim($currentFilterPath, '/');
-                $url = str_replace($currentFilterPath . '/', $newFilterPath . '/', $currentUrl);
+                $url = str_replace(
+                    sprintf('%s/', rtrim($currentFilterPath, '/')),
+                    sprintf('%s/', $newFilterPath),
+                    $currentUrl
+                );
             } else {
                 $url = $currentUrl . '/' . $newFilterPath;
             }

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -396,7 +396,7 @@ class PathSlugStrategy implements
             // Replace filter path in current URL with the new filter combination path
             if (strpos($currentUrl, $currentFilterPath) !== false) {
                 rtrim($currentFilterPath, '/');
-                $url = str_replace($currentFilterPath.'/', $newFilterPath.'/', $currentUrl);
+                $url = str_replace($currentFilterPath . '/', $newFilterPath . '/', $currentUrl);
             } else {
                 $url = $currentUrl . '/' . $newFilterPath;
             }


### PR DESCRIPTION
This pull request fixes an issue with the clear/remove filter url when using an alp with the same url as the selected filter.

How to reproduce

- Enable ajax navigation
- Use seo path slugs for url strategy
- Make an alp with the same url as an filter + value as part of the url. For example: /merken/4-seasons-outdoor-tuinmeubelen/4-seasons-outdoor-capalbio. This url contains the name of the filter /merken/4-seasons-outdoor.
- When selecting the filter you get an url like: merken/4-seasons-outdoor-tuinmeubelen/4-seasons-outdoor-capalbio/merken/4-seasons-outdoor/
- Go remove the filter or click on the clear all filters button.
- See that the url is not /merken/4-seasons-outdoor-tuinmeubelen/4-seasons-outdoor-capalbio but /-tuinmeubelen/4-seasons-outdoor-capalbio

Because the url contains the filter + value it gets removed. This pull request fixes that. The url part is only removed if it ends with an slash. Or with nothing.