### PR TITLE
feat: implement search banner functionality

### DIFF
--- a/Model/Catalog/Layer/NavigationContext.php
+++ b/Model/Catalog/Layer/NavigationContext.php
@@ -161,11 +161,23 @@ class NavigationContext
 
             if (!$this->config->getTweakwiseExceptionTrown()) {
                 try {
-                    $this->response = $this->client->request($request);
-                } catch (ApiException $e) {
-                    //no api response
-                    throw $e;
-                }
+                     $this->response = $this->client->request($request);
++                    
+                     //Request number two to searchbanners if needed
++                    if ($this->showSearchBanners() && $request instanceof ProductSearchRequest) {
+                         $this->response->setValue('searchbanners', []);
++                        $searchQuery = $request->getParameter('tn_q');
++                        $request->setPath('searchbanners');
++                        $request->setParameters(['tn_cid' => '10001185', 'tn_q' => $searchQuery]);
++                        $searchBannerResponse = $this->client->request($request);
++                        if ($searchBannerResponse->hasValue('searchbanner')) {
++                            $this->response->setValue(
++                                'searchbanners',
++                                ['searchbanner' => $searchBannerResponse->getValue('searchbanner')]
++                            );
++                        }
++                    }
+
             } else {
                 throw new ApiException('Tweakwise API is not reachable');
             }


### PR DESCRIPTION
I'm not entirely sure but it seems like the searchbanner functionality (SearchBannerRender) only **applies** the searchbanner data from the navigation context but this data is never fetched. This commit adds an extra request to the searchbanners API to fetch this data and add it to the value of the response.