### PR TITLE
fix: hyva analytics

### DIFF
--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -23,7 +23,7 @@ class Analytics extends Action
      * @param Client                      $client
      * @param PersonalMerchandisingConfig $config
      * @param RequestFactory              $requestFactory
-     * @param jsonSerializer              $jsonSerializer
+     * @param JsonSerializer              $jsonSerializer
      */
     public function __construct(
         private Context $context,

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -7,12 +7,11 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Tweakwise\Magento2Tweakwise\Model\Client;
 use Tweakwise\Magento2Tweakwise\Model\PersonalMerchandisingConfig;
-use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
-use Magento\Framework\Stdlib\CookieManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Client\RequestFactory;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Serialize\Serializer\Json as jsonSerializer;
 
 class Analytics extends Action
 {
@@ -24,13 +23,15 @@ class Analytics extends Action
      * @param Client                      $client
      * @param PersonalMerchandisingConfig $config
      * @param RequestFactory              $requestFactory
+     * @param jsonSerializer              $jsonSerializer
      */
     public function __construct(
         private Context $context,
         private JsonFactory $resultJsonFactory,
         private Client $client,
         private PersonalMerchandisingConfig $config,
-        private RequestFactory $requestFactory
+        private RequestFactory $requestFactory,
+        private readonly jsonSerializer $jsonSerializer
     ) {
         parent::__construct($context);
     }
@@ -49,9 +50,9 @@ class Analytics extends Action
 
             //hyva theme
             if (empty($type)) {
-                $contentDecoded = json_decode($request->getContent(), true);
-                $type = isset($contentDecoded['type']) ? $contentDecoded['type'] : $type;
-                $value = isset($contentDecoded['value']) ? $contentDecoded['value'] : $value;
+                $contentDecoded = $this->jsonSerializer->unserialize($request->getContent());
+                $type = $contentDecoded['type'] ?? $type;
+                $value = $contentDecoded['value'] ?? $value;
             }
 
             $tweakwiseRequest = $this->requestFactory->create();

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -11,7 +11,7 @@ use Tweakwise\Magento2Tweakwise\Model\Client\RequestFactory;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultInterface;
-use Magento\Framework\Serialize\Serializer\Json as jsonSerializer;
+use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 
 class Analytics extends Action
 {
@@ -31,7 +31,7 @@ class Analytics extends Action
         private Client $client,
         private PersonalMerchandisingConfig $config,
         private RequestFactory $requestFactory,
-        private readonly jsonSerializer $jsonSerializer
+        private readonly JsonSerializer $jsonSerializer
     ) {
         parent::__construct($context);
     }
@@ -50,9 +50,9 @@ class Analytics extends Action
 
             //hyva theme
             if (empty($type)) {
-                $contentDecoded = $this->jsonSerializer->unserialize($request->getContent());
-                $type = $contentDecoded['type'] ?? $type;
-                $value = $contentDecoded['value'] ?? $value;
+                $content = $this->jsonSerializer->unserialize($request->getContent());
+                $type = $content['type'] ?? null;
+                $value = $content['value'] ?? null;
             }
 
             $tweakwiseRequest = $this->requestFactory->create();

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -42,12 +42,20 @@ class Analytics extends Action
     {
         $result = $this->resultJsonFactory->create();
         if ($this->config->isAnalyticsEnabled()) {
-            $type = $this->getRequest()->getParam('type');
+            $request = $this->getRequest();
+            $type = $request->getParam('type');
+            $value = $request->getParam('value');
             $profileKey = $this->config->getProfileKey();
+
+            //hyva theme
+            if (empty($type)) {
+                $contentDecoded = json_decode($request->getContent(), true);
+                $type = isset($contentDecoded['type']) ? $contentDecoded['type'] : $type;
+                $value = isset($contentDecoded['value']) ? $contentDecoded['value'] : $value;
+            }
 
             $tweakwiseRequest = $this->requestFactory->create();
             $tweakwiseRequest->setProfileKey($profileKey);
-            $value = $this->getRequest()->getParam('value');
 
             if ($type === 'product') {
                 $tweakwiseRequest->setParameter('productKey', $value);


### PR DESCRIPTION
When tweakwise analytics is enabled. And you use the hyva theme the type and value is never set. This is because hyva sends the parameters diffrently then the luma theme. This pull request fixes that.