### PR TITLE
Fix remove dot profilekey

### DIFF
--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -81,6 +81,6 @@ class PersonalMerchandisingConfig extends Config
      */
     private function generateProfileKey(): string
     {
-        return uniqid('', true);
+        return str_replace('.', '', uniqid('', true));
     }
 }

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -18,6 +18,21 @@ use Magento\Framework\Math\Random;
 
 class PersonalMerchandisingConfig extends Config
 {
+    /**
+     * Constructor.
+     *
+     * @param ScopeConfigInterface   $config
+     * @param Json                   $jsonSerializer
+     * @param RequestInterface       $request
+     * @param State                  $state
+     * @param WriterInterface        $configWriter
+     * @param TypeListInterface      $cacheTypeList
+     * @param CookieManagerInterface $cookieManager
+     * @param CookieMetadataFactory  $cookieMetadataFactory
+     * @param Random                 $mathRandom
+     *
+     * @throws LocalizedException
+     */
     public function __construct(
         ScopeConfigInterface $config,
         Json $jsonSerializer,

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -14,6 +14,7 @@ use Tweakwise\Magento2Tweakwise\Model\Config;
 use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
 use Magento\Store\Model\Store;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Math\Random;
 
 class PersonalMerchandisingConfig extends Config
 {
@@ -25,7 +26,8 @@ class PersonalMerchandisingConfig extends Config
         WriterInterface $configWriter,
         TypeListInterface $cacheTypeList,
         private readonly CookieManagerInterface $cookieManager,
-        private readonly CookieMetadataFactory $cookieMetadataFactory
+        private readonly CookieMetadataFactory $cookieMetadataFactory,
+        private readonly Random $mathRandom
     ) {
         parent::__construct($config, $jsonSerializer, $request, $state, $configWriter, $cacheTypeList);
     }
@@ -81,6 +83,6 @@ class PersonalMerchandisingConfig extends Config
      */
     private function generateProfileKey(): string
     {
-        return str_replace('.', '', uniqid('', true));
+        return $this->mathRandom->getUniqueHash();
     }
 }


### PR DESCRIPTION
This fix removes the dot from the profile key since only characters are allowed. An . in the profile key causes the personal merchandising requests to not be personalised.