### PR TITLE
fix: html button

### DIFF
--- a/view/frontend/templates/layer/view.phtml
+++ b/view/frontend/templates/layer/view.phtml
@@ -102,7 +102,7 @@ if (!$block->canShowBlock()) {
                     <?php if ($renderFilterButton): ?>
                         <div class="show-items-link">
                             <button type="button" class="btn btn-primary btn-block js-btn-filter">
-                                <?= $escaper->escapeHtml(__(sprintf('Show <span>%s</span> items', $block->getLayer()->getProductCount()))); ?>
+                                <?= $escaper->escapeHtml(__(sprintf('Show %s items', $block->getLayer()->getProductCount()))); ?>
                             </button>
                         </div>
                     <?php endif;?>


### PR DESCRIPTION
When you have the filter form enabled in the layered navigation tweakwise settings in magento. The html is shown as text instead of html. This pull request fixes that by removed the html.