### PR TITLE
fix: swatch not set

### DIFF
--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -24,6 +24,9 @@ use Magento\Framework\Escaper;
     <div class="swatch-attribute-options clearfix">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
             <?php $item = $block->getItemForSwatch($option);?>
+            <?php if (!$item) {
+                continue;
+            } ?>
             <a <?=$block->renderAnchorHtmlTagAttributes($item);?>
                 aria-label="<?=  $label['label'] ?>"
                 class="swatch-option-link-layered"

--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -24,9 +24,7 @@ use Magento\Framework\Escaper;
     <div class="swatch-attribute-options clearfix">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
             <?php $item = $block->getItemForSwatch($option);?>
-            <?php if (!$item) {
-                continue;
-            } ?>
+            <?php if (!$item) continue; ?>
             <a <?=$block->renderAnchorHtmlTagAttributes($item);?>
                 aria-label="<?=  $label['label'] ?>"
                 class="swatch-option-link-layered"


### PR DESCRIPTION
The function getItemForSwatch can return null. If that happens the code should continue because the tweakwise filter for it can't be found.

If not, it causes an error for the renderAchorHtmlTagAttributes function.

How to reproduce. Don't have an attribute with type swatch in magento.