### PR TITLE
Fix: category url double store code

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -593,6 +593,9 @@ class PathSlugStrategy implements
             $url .= '/' . trim($filterSlugPath, '/');
         }
 
+        //remove double slashes with exception for the protocol
+        $url = preg_replace('#(?<!:)//+#', '/', $url);
+
         /*
          We explode the url so that we can capture its parts and find the double values in order to remove them.
          This is needed because the categoryUrlPath contains the store code in some cases and the directUrl as well.
@@ -613,9 +616,6 @@ class PathSlugStrategy implements
         }
 
         $url = implode('/', $filteredParts);
-
-        //remove double slashes with exception for the protocol
-        $url = preg_replace('#(?<!:)//+#', '/', $url);
 
         return $url;
     }


### PR DESCRIPTION
When you have the store code enabled in the url for the store, the category url's are not correct. The contain the store code twice.(store.nl/default/default/category) This pull request fixes that.

The bug was causes by the url containing double slashes, so the check for double store codes was not working. (store.nl/default//default/category)

By moving the code that removes the double slash the check now works again.

