### PR TITLE
fix: hidden active filters

### DIFF
--- a/Model/Catalog/Layer/FilterList/Tweakwise.php
+++ b/Model/Catalog/Layer/FilterList/Tweakwise.php
@@ -176,6 +176,10 @@ class Tweakwise
             return false;
         }
 
+        if (count($filter->getActiveItems()) > 0) {
+            return false;
+        }
+
         return count($filter->getItems()) === 1;
     }
 


### PR DESCRIPTION
This pull request fixes an issue with an active filter that is hidden because it has one value. So the filter is not shown as selected.

How to reproduce
- Make an filter with 2 values (yes/no)
- Make sure it is not an multiple choice filter in tweakwise
- Have the setting 'hide facets with only one option' set to yes in magento in the tweakwise layered navigation settings
- Select one of the two values
- See that the product selection changes, but the selected filter is not shown as active.