### PR TITLE
fix: Add support to php8.4

### DIFF
--- a/Model/Catalog/Layer/Filter.php
+++ b/Model/Catalog/Layer/Filter.php
@@ -108,7 +108,7 @@ class Filter extends AbstractFilter implements FilterInterface
         FacetType $facet,
         ItemFactory $itemFactory,
         StoreManager $storeManager,
-        Attribute $attribute = null
+        ?Attribute $attribute = null
     ) {
         $this->layer = $layer;
         $this->facet = $facet;

--- a/Model/Catalog/Layer/NavigationContext.php
+++ b/Model/Catalog/Layer/NavigationContext.php
@@ -213,7 +213,7 @@ class NavigationContext
      * @param array $attributeCodes
      * @return Attribute[]
      */
-    public function getFilterAttributeMap(array $attributeCodes = null): array
+    public function getFilterAttributeMap(?array $attributeCodes = null): array
     {
         if ($this->filterAttributeMap === null) {
             $map = [];

--- a/Model/Catalog/Layer/Url/UrlModel.php
+++ b/Model/Catalog/Layer/Url/UrlModel.php
@@ -71,8 +71,8 @@ class UrlModel extends MagentoUrl
         Config $config,
         array $tweakwiseSystemParams = [],
         array $data = [],
-        HostChecker $hostChecker = null,
-        Json $serializer = null
+        ?HostChecker $hostChecker = null,
+        ?Json $serializer = null
     ) {
         parent::__construct(
             $routeConfig,

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -93,7 +93,7 @@ class Collection extends AbstractCollection
         NavigationContext $navigationContext,
         private readonly VisualFactory $visualFactory,
         private readonly Config $config,
-        AdapterInterface $connection = null
+        ?AdapterInterface $connection = null
     ) {
         parent::__construct(
             $entityFactory,

--- a/Model/Catalog/Product/Recommendation/Collection.php
+++ b/Model/Catalog/Product/Recommendation/Collection.php
@@ -63,7 +63,7 @@ class Collection extends AbstractCollection
         DateTime $dateTime,
         GroupManagementInterface $groupManagement,
         RecommendationsResponse $response,
-        AdapterInterface $connection = null
+        ?AdapterInterface $connection = null
     ) {
         parent::__construct(
             $entityFactory,

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -138,7 +138,7 @@ class Request
      * @param string|null $value
      * @return $this
      */
-    public function setParameter(string $parameter, string $value = null)
+    public function setParameter(string $parameter, ?string $value = null)
     {
         if ($value === null) {
             unset($this->parameters[$parameter]);

--- a/Model/Client/Request/SearchRequestTrait.php
+++ b/Model/Client/Request/SearchRequestTrait.php
@@ -19,7 +19,7 @@ trait SearchRequestTrait
      * @param string|null $value
      * @return mixed
      */
-    abstract public function setParameter(string $parameter, string $value = null);
+    abstract public function setParameter(string $parameter, ?string $value = null);
 
     /**
      * @param string $parameter

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -31,7 +31,7 @@ class Response extends Type
      * @param Request $request
      * @param array $data
      */
-    public function __construct(Helper $helper, Request $request, array $data = null)
+    public function __construct(Helper $helper, Request $request, ?array $data = null)
     {
         $this->request = $request;
         $this->helper = $helper;

--- a/Model/Client/Response/RecommendationsResponse.php
+++ b/Model/Client/Response/RecommendationsResponse.php
@@ -34,7 +34,7 @@ class RecommendationsResponse extends Response
         Helper $helper,
         Request $request,
         private readonly Config $config,
-        array $data = null
+        ?array $data = null
     ) {
         parent::__construct(
             $helper,

--- a/Model/Client/Response/Suggestions/SuggestionsResponse.php
+++ b/Model/Client/Response/Suggestions/SuggestionsResponse.php
@@ -26,7 +26,7 @@ class SuggestionsResponse extends Response
         SuggestionTypeGroupFactory $suggestionTypeGroupFactory,
         Helper $helper,
         Request $request,
-        array $data = null
+        ?array $data = null
     ) {
         $this->suggestionTypeGroupFactory = $suggestionTypeGroupFactory;
         parent::__construct($helper, $request, $data);

--- a/Model/Client/Type/SuggestionType/SuggestionTypeFactory.php
+++ b/Model/Client/Type/SuggestionType/SuggestionTypeFactory.php
@@ -25,7 +25,7 @@ class SuggestionTypeFactory
      * @param string|null $type
      * @return SuggestionTypeAbstract
      */
-    public function createSuggestion(array $suggestion, string $type = null): SuggestionTypeAbstract
+    public function createSuggestion(array $suggestion, ?string $type = null): SuggestionTypeAbstract
     {
         $type = $this->resolveClass($type);
         /** @var SuggestionTypeAbstract $suggestionType */

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -172,7 +172,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getGeneralAuthenticationKey(Store $store = null)
+    public function getGeneralAuthenticationKey(?Store $store = null)
     {
         return (string)$this->getStoreConfig('tweakwise/general/authentication_key', $store);
     }
@@ -191,7 +191,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isLayeredEnabled(Store $store = null)
+    public function isLayeredEnabled(?Store $store = null)
     {
         if ($this->tweakwiseExceptionThrown) {
             return false;
@@ -204,7 +204,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAjaxFilters(Store $store = null)
+    public function isAjaxFilters(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/layered/ajax_filters', $store);
     }
@@ -214,7 +214,7 @@ class Config
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
-    public function getCategoryAsLink(Store $store = null)
+    public function getCategoryAsLink(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/layered/category_links', $store);
     }
@@ -224,7 +224,7 @@ class Config
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
-    public function getHideSingleOptions(Store $store = null)
+    public function getHideSingleOptions(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/layered/hide_single_option', $store);
     }
@@ -234,7 +234,7 @@ class Config
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
-    public function getUseDefaultLinkRenderer(Store $store = null)
+    public function getUseDefaultLinkRenderer(?Store $store = null)
     {
         return (bool) $this->getStoreConfig('tweakwise/layered/default_link_renderer', $store);
     }
@@ -243,7 +243,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isFormFilters(Store $store = null)
+    public function isFormFilters(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/layered/form_filters', $store);
     }
@@ -252,7 +252,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getQueryFilterType(Store $store = null)
+    public function getQueryFilterType(?Store $store = null)
     {
         return (string)$this->getStoreConfig('tweakwise/layered/query_filter_type', $store);
     }
@@ -261,7 +261,7 @@ class Config
      * @param Store|null $store
      * @return array
      */
-    public function getQueryFilterArguments(Store $store = null)
+    public function getQueryFilterArguments(?Store $store = null)
     {
         if ($this->parsedFilterArguments === null) {
             $arguments = $this->getStoreConfig('tweakwise/layered/query_filter_arguments', $store);
@@ -278,7 +278,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getQueryFilterRegex(Store $store = null)
+    public function getQueryFilterRegex(?Store $store = null)
     {
         return (string)$this->getStoreConfig('tweakwise/layered/query_filter_regex', $store);
     }
@@ -287,7 +287,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getUrlStrategy(Store $store = null): string
+    public function getUrlStrategy(?Store $store = null): string
     {
         $urlStrategy = $this->getStoreConfig('tweakwise/layered/url_strategy', $store);
         if (empty($urlStrategy)) {
@@ -301,7 +301,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAutocompleteEnabled(Store $store = null)
+    public function isAutocompleteEnabled(?Store $store = null)
     {
         if ($this->tweakwiseExceptionThrown) {
             return false;
@@ -314,7 +314,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isSuggestionsAutocomplete(Store $store = null)
+    public function isSuggestionsAutocomplete(?Store $store = null)
     {
         return (bool) $this->getStoreConfig('tweakwise/autocomplete/use_suggestions', $store);
     }
@@ -323,7 +323,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAutocompleteProductsEnabled(Store $store = null)
+    public function isAutocompleteProductsEnabled(?Store $store = null)
     {
         return (bool)($this->getStoreConfig('tweakwise/autocomplete/show_products', $store) &&
             !$this->isSuggestionsAutocomplete());
@@ -333,7 +333,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAutocompleteSuggestionsEnabled(Store $store = null)
+    public function isAutocompleteSuggestionsEnabled(?Store $store = null)
     {
         return (bool)($this->getStoreConfig('tweakwise/autocomplete/show_suggestions', $store) &&
             !$this->isSuggestionsAutocomplete());
@@ -352,7 +352,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getAutocompleteMaxResults(Store $store = null)
+    public function getAutocompleteMaxResults(?Store $store = null)
     {
         return (int)$this->getStoreConfig('tweakwise/autocomplete/max_results', $store);
     }
@@ -361,7 +361,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isAutocompleteStayInCategory(Store $store = null)
+    public function isAutocompleteStayInCategory(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/autocomplete/in_current_category', $store);
     }
@@ -370,7 +370,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function isSearchEnabled(Store $store = null)
+    public function isSearchEnabled(?Store $store = null)
     {
         return (int)$this->getStoreConfig('tweakwise/search/enabled', $store);
     }
@@ -379,7 +379,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getSearchTemplateId(Store $store = null)
+    public function getSearchTemplateId(?Store $store = null)
     {
         return (int)$this->getStoreConfig('tweakwise/search/template', $store);
     }
@@ -388,7 +388,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isPersonalMerchandisingActive(Store $store = null)
+    public function isPersonalMerchandisingActive(?Store $store = null)
     {
         return (bool) $this->getStoreConfig('tweakwise/merchandising_builder/personal_merchandising/enabled', $store);
     }
@@ -397,7 +397,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isVisualsEnabled(Store $store = null)
+    public function isVisualsEnabled(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/merchandising_builder/visuals/enabled', $store);
     }
@@ -406,7 +406,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isSearchBannersActive(Store $store = null)
+    public function isSearchBannersActive(?Store $store = null)
     {
         return (bool) $this->getStoreConfig('tweakwise/search/searchbanner', $store)
             && $this->isSearchEnabled();
@@ -416,7 +416,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getPersonalMerchandisingCookieName(Store $store = null)
+    public function getPersonalMerchandisingCookieName(?Store $store = null)
     {
         $cookie = $this->getStoreConfig('tweakwise/merchandising_builder/personal_merchandising/cookie_name', $store);
 
@@ -432,7 +432,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isRecommendationsEnabled($type, Store $store = null)
+    public function isRecommendationsEnabled($type, ?Store $store = null)
     {
         $this->validateRecommendationType($type);
         return (bool)$this->getStoreConfig(sprintf('tweakwise/recommendations/%s_enabled', $type), $store);
@@ -452,7 +452,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getRecommendationsTemplate($type, Store $store = null)
+    public function getRecommendationsTemplate($type, ?Store $store = null)
     {
         $this->validateRecommendationType($type);
         return (int)$this->getStoreConfig(sprintf('tweakwise/recommendations/%s_template', $type), $store);
@@ -463,7 +463,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getRecommendationsGroupCode($type, Store $store = null)
+    public function getRecommendationsGroupCode($type, ?Store $store = null)
     {
         $this->validateRecommendationType($type);
         return $this->getStoreConfig(sprintf('tweakwise/recommendations/%s_group_code', $type), $store);
@@ -473,7 +473,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getRecommendationsFeaturedLocation(Store $store = null)
+    public function getRecommendationsFeaturedLocation(?Store $store = null)
     {
         return (string)$this->getStoreConfig('tweakwise/recommendations/featured_location', $store);
     }
@@ -482,7 +482,7 @@ class Config
      * @param Store|null $store
      * @return string
      */
-    public function getRecommendationsFeaturedCategory(Store $store = null)
+    public function getRecommendationsFeaturedCategory(?Store $store = null)
     {
         return (string)$this->getStoreConfig('tweakwise/recommendations/featured_category', $store);
     }
@@ -491,7 +491,7 @@ class Config
      * @param Store|null $store
      * @return bool
      */
-    public function isSeoEnabled(Store $store = null)
+    public function isSeoEnabled(?Store $store = null)
     {
         return (bool)$this->getStoreConfig('tweakwise/seo/enabled', $store);
     }
@@ -500,7 +500,7 @@ class Config
      * @param Store|null $store
      * @return array
      */
-    public function getFilterWhitelist(Store $store = null)
+    public function getFilterWhitelist(?Store $store = null)
     {
         return ConfigAttributeProcessService::extractFilterWhitelist(
             $this->getStoreConfig('tweakwise/seo/filter_whitelist', $store)
@@ -511,7 +511,7 @@ class Config
      * @param Store|null $store
      * @return array
      */
-    public function getFilterValuesWhitelist(Store $store = null): array
+    public function getFilterValuesWhitelist(?Store $store = null): array
     {
         return ConfigAttributeProcessService::extractFilterValuesWhitelist(
             $this->getStoreConfig('tweakwise/seo/filter_values_whitelist', $store)
@@ -522,7 +522,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getLimitGroupCodeItems(Store $store = null): int
+    public function getLimitGroupCodeItems(?Store $store = null): int
     {
         return (int) $this->getStoreConfig('tweakwise/recommendations/limit_group_code_items', $store);
     }
@@ -531,7 +531,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function getMaxAllowedFacets(Store $store = null)
+    public function getMaxAllowedFacets(?Store $store = null)
     {
         return $this->getStoreConfig('tweakwise/seo/max_allowed_facets', $store);
     }
@@ -540,7 +540,7 @@ class Config
      * @param Store|null $store
      * @return mixed|string|null
      */
-    public function getSearchLanguage(Store $store = null)
+    public function getSearchLanguage(?Store $store = null)
     {
         return $this->getStoreConfig('tweakwise/search/language', $store);
     }
@@ -551,7 +551,7 @@ class Config
      * @return mixed|string|null
      * @throws LocalizedException
      */
-    protected function getStoreConfig(string $path, Store $store = null)
+    protected function getStoreConfig(string $path, ?Store $store = null)
     {
         if ($store) {
             return $store->getConfig($path);
@@ -642,7 +642,7 @@ class Config
      * @param Store|null $store
      * @return int
      */
-    public function isCategoryViewDefault(Store $store = null)
+    public function isCategoryViewDefault(?Store $store = null)
     {
         return $this->getStoreConfig('tweakwise/layered/default_category_view', $store);
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -182,7 +182,7 @@ class Config
      * @return bool
      * @throws LocalizedException
      */
-    public function isGroupedProductsEnabled(Store $store = null): bool
+    public function isGroupedProductsEnabled(?Store $store = null): bool
     {
         return (bool)$this->getStoreConfig('tweakwise/general/grouped_products', $store);
     }

--- a/Model/PersonalMerchandisingConfig.php
+++ b/Model/PersonalMerchandisingConfig.php
@@ -52,7 +52,7 @@ class PersonalMerchandisingConfig extends Config
      * @return bool
      * @throws LocalizedException
      */
-    public function isAnalyticsEnabled(Store $store = null): bool
+    public function isAnalyticsEnabled(?Store $store = null): bool
     {
         return (bool)$this->getStoreConfig(
             'tweakwise/merchandising_builder/personal_merchandising/analytics_enabled',


### PR DESCRIPTION
Fix php 8.4 errors -

Deprecated Functionality: Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\Url\UrlModel::__construct(): Implicitly marking parameter $hostChecker as nullable is deprecated, the explicit nullable type must be used instead in vendor/tweakwise/magento2-tweakwise/Model/Catalog/Layer/Url/UrlModel.php on line 59


Deprecated Functionality: Tweakwise\Magento2Tweakwise\Model\Catalog\Layer\NavigationContext::getFilterAttributeMap(): Implicitly marking parameter $attributeCodes as nullable is deprecated, the explicit nullable type must be used instead in vendor/tweakwise/magento2-tweakwise/Model/Catalog/Layer/NavigationContext.php on line 216