### PR TITLE
fix: move itemclick code

### DIFF
--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -21,6 +21,11 @@
                        name="tweakwise.catalog.linked.product.list.item"
                        template="Tweakwise_Magento2Tweakwise::product/list/linked-item.phtml"
                        ifconfig="tweakwise/merchandising_builder/personal_merchandising/enabled"/>
+                <block class="Magento\Framework\View\Element\Template" name="magento2tweakwise.analytics" template="Tweakwise_Magento2Tweakwise::analytics.phtml" ifconfig="tweakwise/general/analytics_enabled">
+                    <arguments>
+                        <argument name="tweakwise_navigation_config" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\NavigationConfig\Category</argument>
+                    </arguments>
+                </block>
             </block>
         </referenceContainer>
         <referenceBlock name="category.products.list">

--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -19,6 +19,7 @@
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Tweakwise\Magento2Tweakwise\ViewModel\PersonalMerchandisingAnalytics</argument>
                     <argument name="analyticsType" xsi:type="string">search</argument>
+                    <argument name="tweakwise_navigation_config" xsi:type="object">Tweakwise\Magento2Tweakwise\Model\NavigationConfig\Category</argument>
                 </arguments>
             </block>
             <block ifconfig="tweakwise/search/searchbanner" before="-" class="Tweakwise\Magento2Tweakwise\Block\Navigation\SearchBanner\SearchBannerRenderer" name="navigation.search.banner.list.top" template="Tweakwise_Magento2Tweakwise::searchbanner/search.banner.list.top.phtml">

--- a/view/frontend/templates/analytics.phtml
+++ b/view/frontend/templates/analytics.phtml
@@ -1,13 +1,14 @@
 <?php
 
 use Magento\Framework\Escaper;
+use Tweakwise\Magento2Tweakwise\Model\NavigationConfig;
 
 /** @var \Tweakwise\Magento2Tweakwise\ViewModel\PersonalMerchandisingAnalytics $viewModel */
 $viewModel = $block->getData('viewModel');
 $analyticsType = $block->getData('analyticsType');
 $value = $viewModel->getValue($analyticsType);
 
-/** @var \Tweakwise\Magento2Tweakwise\Model\NavigationConfig $tweakwiseNavigationConfig */
+/** @var NavigationConfig $tweakwiseNavigationConfig */
 $tweakwiseNavigationConfig = $block->getData('tweakwise_navigation_config');
 $jsFormConfig = $tweakwiseNavigationConfig ? $tweakwiseNavigationConfig->getJsFormConfig() : [];
 ?>

--- a/view/frontend/templates/analytics.phtml
+++ b/view/frontend/templates/analytics.phtml
@@ -6,16 +6,26 @@ use Magento\Framework\Escaper;
 $viewModel = $block->getData('viewModel');
 $analyticsType = $block->getData('analyticsType');
 $value = $viewModel->getValue($analyticsType);
+
+/** @var \Tweakwise\Magento2Tweakwise\Model\NavigationConfig $tweakwiseNavigationConfig */
+$tweakwiseNavigationConfig = $block->getData('tweakwise_navigation_config');
+$jsFormConfig = $tweakwiseNavigationConfig ? $tweakwiseNavigationConfig->getJsFormConfig() : [];
 ?>
 
 <script type="text/x-magento-init">
     {
         "*": {
             "Tweakwise_Magento2Tweakwise/js/analytics": {
-              "value": "<?= $escaper->escapeHtmlAttr($value); ?>",
-              "type": "<?= $escaper->escapeHtmlAttr($analyticsType); ?>"
+                "value": "<?= $escaper->escapeHtmlAttr($value ?? ''); ?>",
+                "type": "<?= $escaper->escapeHtmlAttr($analyticsType ?? ''); ?>",
+                "bindItemClickEventsConfig": {
+                    "productListSelector": "<?= $escaper->escapeHtmlAttr($jsFormConfig['tweakwiseNavigationForm']['productListSelector'] ?? ''); ?>",
+                    "productSelector": "<?= $escaper->escapeHtmlAttr($jsFormConfig['tweakwiseNavigationForm']['productSelector'] ?? ''); ?>",
+                    "analyticsEndpoint": "<?= $escaper->escapeHtmlAttr($jsFormConfig['tweakwiseNavigationForm']['analyticsEndpoint'] ?? ''); ?>",
+                    "twRequestId": "<?= $escaper->escapeHtmlAttr($jsFormConfig['tweakwiseNavigationForm']['twRequestId'] ?? ''); ?>"
+                }
+            }
         }
     }
-}
 </script>
 <script src="<?= $escaper->escapeHtmlAttr($block->getViewFileUrl('Tweakwise_Magento2Tweakwise::js/analytics.js')); ?>"></script>

--- a/view/frontend/web/js/analytics.js
+++ b/view/frontend/web/js/analytics.js
@@ -1,21 +1,91 @@
 define('Tweakwise_Magento2Tweakwise/js/analytics', ['jquery'], function($) {
     'use strict';
 
-    return function(config) {
-        $(document).ready(function() {
-            var requestData = {
-                type: config.type,
-                value: config.value
-            };
+    function handleItemClick(event, config) {
+        try {
+            if (!config.twRequestId) {
+                return;
+            }
 
+            const product = $(event.target).closest(`.${config.productSelector}`)[0];
+            let productId;
+
+            if (!product || !product.id) {
+                const visual = $(event.target).closest('.visual');
+                if (!visual.length) {
+                    const link = $(event.target).closest('a');
+                    if (link.length) {
+                        visual = link.find('.visual');
+                    }
+
+                    if (!visual.length) {
+                        return;
+                    }
+                }
+                productId = visual.attr('id');
+            } else {
+                productId = product.id.replace(`${config.productSelector}_`, '');
+            }
+
+            if (!productId) {
+                return;
+            }
+
+            // Send async AJAX request to the analytics endpoint
             $.ajax({
-                url: '/tweakwise/ajax/analytics',
-                method: 'POST',
-                data: requestData,
-                error: function(error) {
-                    console.error('Tweakwise API call failed:', error);
+                url: config.analyticsEndpoint,
+                type: 'POST',
+                data: {
+                    type: 'itemclick',
+                    value: productId,
+                    requestId: config.twRequestId
+                },
+                cache: false,
+                success: function(response) {
+                    // Do nothing
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    console.error('Error sending analytics event', textStatus, errorThrown);
                 }
             });
+        } catch (error) {
+            console.error('Error handling product click event', error);
+        }
+    }
+
+    return function(config) {
+        $(document).ready(function() {
+
+            // send item or search view event
+            if (config.type && config.value) {
+                var requestData = {
+                    type: config.type,
+                    value: config.value
+                };
+
+                $.ajax({
+                    url: '/tweakwise/ajax/analytics',
+                    method: 'POST',
+                    data: requestData,
+                    error: function(error) {
+                        console.error('Tweakwise API call failed:', error);
+                    }
+                });
+            }
+
+            // bindItemClickEvents
+            if (config.bindItemClickEventsConfig) {
+                const bindConfig = config.bindItemClickEventsConfig;
+                const productList = $(bindConfig.productListSelector);
+
+                if (!bindConfig.twRequestId || !productList.length) {
+                    return;
+                }
+
+                productList.on('click', bindConfig.productSelector, function(event) {
+                    handleItemClick(event, bindConfig);
+                });
+            }
         });
     };
 });


### PR DESCRIPTION
Improvement:
Relocate the analytics code for the itemClick event so it also works with the default Magento renderer.

Steps to Reproduce:

Set "Use default Magento filter renderer" to Yes.

Enable "Send analytics events to Tweakwise".

Check the console — notice that the itemClick event is never sent.