### PR TITLE
fix: prevent ajax navigation for query parameter strategy

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -244,12 +244,13 @@ define([
          */
         _findHref: function (aElement) {
             var href = aElement.attr('href');
+            var noAjax = aElement.data('no-ajax');
             if (this.options.seoEnabled) {
                 var seoHref = aElement.data('seo-href');
                 href = seoHref ? seoHref : href;
             }
 
-            if (this.options.urlStrategy === 'queryparameter') {
+            if (this.options.urlStrategy === 'queryparameter' && !noAjax) {
                 let url = new URL(href, window.location.origin);
                 url.search = this._getFilterParameters();
                 return url.toString();


### PR DESCRIPTION
## Fix: Wrong URL used instead of ALP

This PR fixes an issue where the AJAX URL was called instead of the ALP URL.

### Steps to Reproduce

1. Enable the following settings:
   - **URL strategy**: Query parameters  
   - **AJAX**: Enabled  

2. Configure an ALP with:
   - A filter using a color swatch (e.g., **Color = Green**)  
   - **Show link in facet navigation**: Yes  
   - A selected category  

3. Go to the category page where the color filter should link to the ALP.

### Expected Result
Selecting the color green should go to the **ALP URL**.

### Actual Result
Selecting the color green goes to a page with **AJAX filters in the URL** instead of the ALP URL.
