### PR TITLE
Fix:filter special chars from filtersearch

### DIFF
--- a/view/frontend/web/js/navigation-sort.js
+++ b/view/frontend/web/js/navigation-sort.js
@@ -75,6 +75,20 @@ define([
             }).appendTo(list);
         },
 
+        _asciiFold: function (value) {
+            const SPECIAL_MAP = {
+                'ß': 'ss', 'Æ': 'AE', 'æ': 'ae', 'Ø': 'O', 'ø': 'o', 'Œ': 'OE', 'œ': 'oe',
+                'Þ': 'Th', 'þ': 'th', 'Đ': 'D', 'đ': 'd', 'Ł': 'L', 'ł': 'l', 'Ħ': 'H', 'ħ': 'h'
+            };
+            const SPECIAL_REGEX = new RegExp(Object.keys(SPECIAL_MAP).join('|'), 'g');
+            return value.normalize('NFKD')
+                .replace(/\p{M}/gu, '')
+                .replace(SPECIAL_REGEX, ch => SPECIAL_MAP[ch])
+                .normalize('NFC')
+                .toLowerCase()
+                .trim();
+        },
+
         _handleFilterSearch: function () {
             var filterInput = this.element.find('.tw_filtersearch');
             var value = filterInput.val().toLowerCase().trim();
@@ -84,6 +98,7 @@ define([
             var filterElement = 'li';
             var moreItems = filterInput.parent('div').find('.more-items');
             var lessItems = filterInput.parent('div').find('.less-items');
+            var self = this;
 
             if (items.length === 0) {
                 //swatch
@@ -95,7 +110,7 @@ define([
             var filterItems = items.find(filterElement);
 
             filterItems.show().filter(function () {
-                return $(this).find('input').val().toLowerCase().trim().indexOf(value) === -1;
+                return self._asciiFold(input.val()).indexOf(self._asciiFold(value)) === -1;
             }).hide();
 
             //more items visible than max visible items


### PR DESCRIPTION
When you have an special character like ä in an filter value. Searching on a doesn't give an result. This pull request fixes that.