### PR TITLE
fix: product image url

### DIFF
--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -190,6 +190,10 @@ class Collection extends AbstractCollection
                 continue;
             }
 
+            if (empty($productImageUrl)) {
+                continue;
+            }
+
             $this->_items[$productId]->setData('image', $productImageUrl);
             $this->_items[$productId]->setData('small_image', $productImageUrl);
             $this->_items[$productId]->setData('thumbnail', $productImageUrl);

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -171,7 +171,7 @@ class Collection extends AbstractCollection
         if ($this->config->isGroupedProductsEnabled()) {
             $this->applyProductImages();
         }
-        
+
         $this->addVisuals();
 
         return $this;

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -171,6 +171,7 @@ class Collection extends AbstractCollection
         if ($this->config->isGroupedProductsEnabled()) {
             $this->applyProductImages();
         }
+        
         $this->addVisuals();
 
         return $this;

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -168,7 +168,9 @@ class Collection extends AbstractCollection
         parent::_afterLoad();
 
         $this->applyCollectionSizeValues();
-        $this->applyProductImages();
+        if ($this->config->isGroupedProductsEnabled()) {
+            $this->applyProductImages();
+        }
         $this->addVisuals();
 
         return $this;


### PR DESCRIPTION
The product image url only needs to be loaded from tweakwise when grouped products is enabled