### PR TITLE
send page parameter with history request

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -49,10 +49,12 @@ define([
         _fixAjaxHistory: function () {
             if(this.options.ajaxFilters && this.options.ajaxCache && (!window.history.state || !window.history.state.html))
             {
+                const page = new URL(window.location.href).searchParams.get('p');
+                let data = this._getFilterParameters() + (page ? '&p=' + page : '');
                 //if window history is empty, do an ajax request to fill it.
                 this.currentXhr = $.ajax({
                     url: this.options.ajaxEndpoint,
-                    data: this._getFilterParameters(),
+                    data: data,
                     cache: this.options.ajaxCache,
                     success: function (response) {
                         this._replaceState(response);

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -50,7 +50,7 @@ define([
             if(this.options.ajaxFilters && this.options.ajaxCache && (!window.history.state || !window.history.state.html))
             {
                 const page = new URL(window.location.href).searchParams.get('p');
-                let data = this._getFilterParameters() + (page ? '&p=' + page : '');
+                let data = this._getFilterParameters() + (page ? `&p=${page}` : '');
                 //if window history is empty, do an ajax request to fill it.
                 this.currentXhr = $.ajax({
                     url: this.options.ajaxEndpoint,


### PR DESCRIPTION
How to reproduce

- Enable ajax filters
- Open an new incognito window on an category page with ?p=2 in the url
- This only happens on the first pageload in an new incognito window

Expected result
- ?p=2 remains visible in the url

Actual result
- ?p=2 gets removed from the url after an ajax request.