### PR TITLE
Fix: Don't hide category when there is one entry

### DIFF
--- a/Model/Catalog/Layer/FilterList/Tweakwise.php
+++ b/Model/Catalog/Layer/FilterList/Tweakwise.php
@@ -176,6 +176,10 @@ class Tweakwise
             return false;
         }
 
+        if ($filter->getFacet()->getFacetSettings()->getSource() === SettingsType::SOURCE_CATEGORY) {
+            return false;
+        }
+
         if (count($filter->getActiveItems()) > 0) {
             return false;
         }


### PR DESCRIPTION
When an category only has one entry, it shoudn't be hidden when hide facets with only one option is on.

This is because the category can have sub categories.