### PR TITLE
fix: remove filter query parameter

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -475,7 +475,10 @@ define([
                 }
             }
 
-            resultUrl.search = queryParamsString;
+            if (!resultUrl.searchParams.length === 0) {
+                resultUrl.search = queryParamsString;
+            }
+
             let result = resultUrl.toString();
             result = this._normalizeQueryString(result);
 

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -34,6 +34,7 @@ define([
         },
 
         currentXhr: null,
+        deletedFilters: [],
 
         _create: function () {
             this._hookEvents();
@@ -209,6 +210,8 @@ define([
                     keysForDel.push(key);
                 }
             });
+
+            this.deletedFilters = keysForDel;
 
             //remove empty parameters
             keysForDel.forEach(key => {
@@ -475,10 +478,6 @@ define([
                 }
             }
 
-            if (!resultUrl.searchParams.length === 0) {
-                resultUrl.search = queryParamsString;
-            }
-
             let result = resultUrl.toString();
             result = this._normalizeQueryString(result);
 
@@ -516,6 +515,12 @@ define([
             responseQueryString.forEach((value, key) => {
                 if (false === uniqueQueryParams.has(key)) {
                     uniqueQueryParams.append(key, value);
+                }
+            });
+
+            uniqueQueryParams.forEach((value, key) => {
+                if (this.deletedFilters.includes(key)) {
+                    uniqueQueryParams.delete(key);
                 }
             });
 


### PR DESCRIPTION
How to reproduce.

- Enable ajax filtering
- Set the url stategy to query parameters
- Go to an cateogry page and enable an filter.
- Then remove the filter

Expected result

- The filter is removed from the url

Actual result

- The removal of the filter is applied but the url still contains the removed filter.