### PR TITLE
Make sure value is a string before attempting to trim it

### DIFF
--- a/Model/Client/Request/ProductNavigationRequest.php
+++ b/Model/Client/Request/ProductNavigationRequest.php
@@ -56,7 +56,7 @@ class ProductNavigationRequest extends Request
      */
     public function addAttributeFilter(string $attribute, $value)
     {
-        $this->addParameter('tn_fk_' . $attribute, trim($value));
+        $this->addParameter('tn_fk_' . $attribute, trim((string)($value ?? '')));
         return $this;
     }
 

--- a/Model/Client/Request/ProductNavigationRequest.php
+++ b/Model/Client/Request/ProductNavigationRequest.php
@@ -56,6 +56,11 @@ class ProductNavigationRequest extends Request
      */
     public function addAttributeFilter(string $attribute, $value)
     {
+        $trimmed = trim((string)($value ?? ''));
+        if ($trimmed === '') {
+            return $this;
+        }
+
         $this->addParameter('tn_fk_' . $attribute, trim((string)($value ?? '')));
         return $this;
     }


### PR DESCRIPTION
Hi,

We noticed that $value was null for some customers, while trim() expects a string type. This change ensures that $value is a value of string and no exception is thrown.