### PR TITLE
fix: Fixed issue when recommendation returns no items 

### DIFF
--- a/Model/Client/Response/RecommendationsResponse.php
+++ b/Model/Client/Response/RecommendationsResponse.php
@@ -69,6 +69,10 @@ class RecommendationsResponse extends Response
     {
         if ($this->config->isGroupedProductsEnabled() && !$this->proccessedGroupedProducts) {
             // Manually group items since recommendations doesn't have a grouped call yet.
+            if (!$this->hasValue('items')) {
+                return [];
+            }
+
             // @phpstan-ignore-next-line
             $items = parent::getItems();
             $groups = [];


### PR DESCRIPTION
When a recommendation didn't return any items, the code entered a recursive loop. This has been fixed in these code changes.