### PR TITLE
Feat: language config

### DIFF
--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -364,7 +364,7 @@ class Request
     /**
      * @return void
      */
-    public function setLang(): void
+    public function setLanguage(): void
     {
         $language = $this->config->getLanguage();
         if (!$language) {

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -360,4 +360,17 @@ class Request
     {
         return false;
     }
+
+    /**
+     * @return void
+     */
+    public function setLang(): void
+    {
+        $language = $this->config->getLanguage();
+        if (!$language) {
+            return;
+        }
+
+        $this->setParameter('tn_lang', $language);
+    }
 }

--- a/Model/Client/Request/SearchRequestTrait.php
+++ b/Model/Client/Request/SearchRequestTrait.php
@@ -44,7 +44,6 @@ trait SearchRequestTrait
     {
         $this->setParameter('tn_q', $query);
         $this->setDefaultCategory();
-        $this->setSearchLanguage();
     }
 
     /**
@@ -72,18 +71,5 @@ trait SearchRequestTrait
         }
 
         return null;
-    }
-
-    /**
-     * @return void
-     */
-    protected function setSearchLanguage(): void
-    {
-        $language = $this->config->getSearchLanguage();
-        if (!$language) {
-            return;
-        }
-
-        $this->setParameter('tn_lang', $language);
     }
 }

--- a/Model/Client/RequestFactory.php
+++ b/Model/Client/RequestFactory.php
@@ -45,7 +45,7 @@ class RequestFactory
         if (!$request instanceof Request) {
             throw new InvalidArgumentException(sprintf('%s is not an instanceof %s', $this->type, Request::class));
         }
-        $request->setLang();
+        $request->setLanguage();
 
         return $request;
     }

--- a/Model/Client/RequestFactory.php
+++ b/Model/Client/RequestFactory.php
@@ -45,6 +45,7 @@ class RequestFactory
         if (!$request instanceof Request) {
             throw new InvalidArgumentException(sprintf('%s is not an instanceof %s', $this->type, Request::class));
         }
+        $request->setLang();
 
         return $request;
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -554,9 +554,9 @@ class Config
      * @param Store|null $store
      * @return mixed|string|null
      */
-    public function getSearchLanguage(?Store $store = null)
+    public function getLanguage(?Store $store = null)
     {
-        return $this->getStoreConfig('tweakwise/search/language', $store);
+        return $this->getStoreConfig('tweakwise/general/language', $store);
     }
 
     /**

--- a/Model/Config/Source/Language.php
+++ b/Model/Config/Source/Language.php
@@ -45,7 +45,7 @@ class Language implements OptionSourceInterface
     {
         $options = [
             [
-                'label' => 'Don\'t use language in search',
+                'label' => __('Default language'),
                 'value' => ''
             ]
         ];

--- a/Setup/Patch/Data/UpdateLanguageConfigs.php
+++ b/Setup/Patch/Data/UpdateLanguageConfigs.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tweakwise\Magento2Tweakwise\Setup\Patch\Data;
+
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class UpdateLanguageConfigs implements DataPatchInterface
+{
+    /**
+     * @param WriterInterface $configWriter
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        private readonly WriterInterface $configWriter,
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    /**
+     * @return $this
+     */
+    public function apply(): UpdateLanguageConfigs
+    {
+        $configurationPaths = [
+            'tweakwise/search/language' =>
+                'tweakwise/general/language',
+        ];
+
+        foreach ($configurationPaths as $oldPath => $newPath) {
+            $value = $this->scopeConfig->getValue($oldPath);
+            if ($value === null) {
+                continue;
+            }
+
+            $this->configWriter->save($newPath, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -27,11 +27,15 @@
                     <label>Cookie name </label>
                     <comment>Name of cookie which holds tweakwise profile information, this is usually set in the tweakwise measure script. Or when analytics is enabled, it is done automaticly and you can leave this empty</comment>
                 </field>
-                <field id="grouped_products" translate="label comment" type="select" sortOrder="30" showInDefault="1"
+                <field id="grouped_products" translate="label comment" type="select" sortOrder="80" showInDefault="1"
                        showInWebsite="1" showInStore="1">
                     <label>Grouped Products</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Display a collection of products with the same groupcode as one product tile.</comment>
+                </field>
+                <field id="language" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Language</label>
+                    <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\Language</source_model>
                 </field>
             </group>
             <group id="layered" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -223,14 +227,6 @@
                 <field id="template" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Tweakwise search template to use in search results</label>
                     <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\FilterTemplate</source_model>
-                    <depends>
-                        <field id="enabled">1</field>
-                    </depends>
-                </field>
-                <field id="language" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Search language</label>
-                    <source_model>Tweakwise\Magento2Tweakwise\Model\Config\Source\Language</source_model>
-                    <comment>Language for search, used to keep track of word conjugations. For example searching for "bed" wil also yield results matching "beds" if english is selected.</comment>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>


### PR DESCRIPTION
**Centralized Language Configuration and Enhanced Search Filtering**

Moves the previously search-specific language setting to the general application configuration section.

Ensures the configured language (via the tn_lang parameter) is correctly included in all relevant requests (not just search) to provide better localization across the application.