### PR TITLE
Fix the queryParamsString never being assigned to new url

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -480,6 +480,7 @@ define([
                 }
             }
 
+            resultUrl.search = queryParamsString;
             let result = resultUrl.toString();
             result = this._normalizeQueryString(result);
 


### PR DESCRIPTION
Commit belongs to [issue 326](https://github.com/EmicoEcommerce/Magento2Tweakwise/issues/326)