### PR TITLE
Fixed issue with duplicate parameter values

### DIFF
--- a/Model/Catalog/Layer/NavigationContext.php
+++ b/Model/Catalog/Layer/NavigationContext.php
@@ -202,17 +202,16 @@ class NavigationContext
      */
     public function resetPagination(): self
     {
-        $params = $this->request->getParameters();
         $params['resetPagination'] = true;
         $params['tn_fk_p'] = 1;
         $params['tn_p'] = 1;
 
         // @phpstan-ignore-next-line
         $this->request = null;
-        $request = $this->getRequest()->setParameters($params);
+        $this->request = $this->getRequest()->setParameters($params);
         $this->response = null;
 
-        return $this->initializeRequest($request);
+        return $this;
     }
 
     /**

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -123,7 +123,7 @@ class Request
                 if (
                     // phpcs:disable SlevomatCodingStandard.Functions.StrictCall.StrictParameterMissing
                     (!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) &&
-                    (!in_array($value, explode('|', $this->parameters[$parameter]), true))
+                    ($this->parameters[$parameter] !== $value)
                 ) {
                     $this->parameters[$parameter] = $this->parameters[$parameter] . $separator . $value;
                 }

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -123,7 +123,7 @@ class Request
                 if (
                     // phpcs:disable SlevomatCodingStandard.Functions.StrictCall.StrictParameterMissing
                     (!in_array($parameter, self::IGNORE_SEPARATOR_PARAMETERS)) &&
-                    ($this->parameters[$parameter] !== $value)
+                    (!in_array($value, explode('|', $this->parameters[$parameter]), true))
                 ) {
                     $this->parameters[$parameter] = $this->parameters[$parameter] . $separator . $value;
                 }


### PR DESCRIPTION
If there are no search results and multiple filters of the same type are used, they will appear twice in the request parameters.

**How to reproduce the issue:**
1. In a clean Magento 2 environment with sample data, go to the URL /gear/fitness-equipment.html?color%5B%5D=Black&size%5B%5D=55+cm&size%5B%5D=6+foot
2. Set a breakpoint in Model/Client/Request.php as shown in the screenshot below.
3. You'll see that the size filter values ​​appear twice.

This is because the system checks whether the value is exactly in the parameters, but doesn't check whether the value is in the list of values.
<img width="1145" height="1186" alt="Scherm­afbeelding 2025-11-27 om 13 45 15" src="https://github.com/user-attachments/assets/f3189b09-dd60-414d-8fd7-a7705dd27423" />
