### PR TITLE
feat: wcag improvements

### DIFF
--- a/view/frontend/templates/layer/state.phtml
+++ b/view/frontend/templates/layer/state.phtml
@@ -43,6 +43,9 @@ use Magento\Framework\Escaper;
                     ?>
                     <a class="action remove" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
                        data-js-filter-id="<?=$escaper->escapeHtmlAttr($block->getActiveFilterCssId($_filter))?>"
+                       tabindex="0"
+                       aria-label="<?=  $escaper->escapeHtmlAttr(__('Remove') . " " . $currentFilterName) ?>"
+                       role="button"
                        title="<?=  $escaper->escapeHtmlAttr(__('Remove') . " " . $currentFilterName)?>">
                         <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                     </a>

--- a/view/frontend/templates/layer/view.phtml
+++ b/view/frontend/templates/layer/view.phtml
@@ -48,6 +48,8 @@ if (!$block->canShowBlock()) {
             <div class="block-actions filter-actions">
                 <a
                     href="<?=$escaper->escapeUrl($block->getClearUrl()) ?>"
+                    tabindex="0"
+                    role="button"
                     class="action clear filter-clear"><span><?=$escaper->escapeHtml(__('Clear All'))?></span>
                 </a>
             </div>
@@ -73,12 +75,23 @@ if (!$block->canShowBlock()) {
                                     "openedState": "active", "collapsible": true, "active": <?=$escaper->escapeHtmlAttr($filterActive)?>
                                 }
                             }'>
-                            <div data-role="collapsible" class="filter-options-item">
+                            <legend style="display: none" id="<?= $escaper->escapeHtmlAttr($filter->getUrlKey()) ?>" class="sr-only"><?= $escaper->escapeHtml($filter->getName())?></legend>
+                            <div
+                                data-role="collapsible"
+                                class="filter-options-item"
+
+                            >
                                 <div data-role="title" class="filter-options-title">
                                     <?=$escaper->escapeHtml(__($filter->getName()))?>
                                     <?php $tooltip = $filter->getTooltip(); ?>
                                     <?php if ($tooltip): ?>
-                                        <span class="tooltip" data-tooltip="<?=$escaper->escapeHtmlAttr($tooltip)?>"><span>i</span></span>
+                                        <span
+                                            class="tooltip"
+                                            tabindex="-1"
+                                            aria-label="<?=$escaper->escapeHtmlAttr($tooltip)?>"
+                                            data-tooltip="<?=$escaper->escapeHtmlAttr($tooltip)?>"
+                                        >
+                                            <span>i</span></span>
                                     <?php endif; ?>
                                 </div>
                                 <?php
@@ -91,7 +104,11 @@ if (!$block->canShowBlock()) {
                         </div>
                     <?php else: ?>
                         <div class="filter-options-item">
-                            <div class="filter-options-title filter-options-title-non-collapsible">
+                            <div
+                                class="filter-options-title filter-options-title-non-collapsible"
+                                tabindex="0"
+                                aria-label="<?= $escaper->escapeHtmlAttr(__('Expand filter options for %1', $filter->getName())) ?>"
+                            >
                                 <?=$escaper->escapeHtml(__($filter->getName()))?>
                             </div>
                             <div class="filter-options-content">
@@ -101,7 +118,12 @@ if (!$block->canShowBlock()) {
                     <?php endif; ?>
                     <?php if ($renderFilterButton): ?>
                         <div class="show-items-link">
-                            <button type="button" class="btn btn-primary btn-block js-btn-filter">
+                            <button
+                                type="button"
+                                class="btn btn-primary btn-block js-btn-filter"
+                                tabindex="0"
+                                aria-label="<?= $escaper->escapeHtmlAttr(__(sprintf('Show %s items', $block->getLayer()->getProductCount()))); ?>"
+                            >
                                 <?= $escaper->escapeHtml(__(sprintf('Show %s items', $block->getLayer()->getProductCount()))); ?>
                             </button>
                         </div>

--- a/view/frontend/templates/product/layered/default.phtml
+++ b/view/frontend/templates/product/layered/default.phtml
@@ -25,6 +25,8 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
 <div data-mage-init='<?=$escaper->escapeHtmlAttr($block->getJsSortConfig())?>'>
     <?php if ($block->isSearchable()): ?>
         <input
+            aria-hidden="true"
+            tabindex="-1"
             data-max-visible="<?= $escaper->escapeHtmlAttr($block->getMaxItemsShown())?>"
             type="text"
             class="tw_filtersearch js-skip-submit"
@@ -40,13 +42,15 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
                     data-original-sort="<?=$escaper->escapeHtmlAttr($index);?>"
                 <?php endif;?>
             >
-                <a <?=$block->renderAnchorHtmlTagAttributes($item);?>>
+                <a aria-hidden="true" tabindex="-1" <?=$block->renderAnchorHtmlTagAttributes($item);?>>
                     <?php $cssId = $item->getCssId();?>
                     <?php if ($showCheckBox): ?>
                         <input id="<?=$escaper->escapeHtmlAttr($cssId)?>"
-                               name="<?=$escaper->escapeHtmlAttr($item->getFilter()->getFacet()->getFacetSettings()->getUrlKey())?>[]"
+                               name="<?=$escaper->escapeHtmlAttr($item->getFilter()->getUrlKey())?>[]"
                                type="checkbox" <?=($item->isSelected() ? 'checked="checked"' : '')?>
                                value="<?=$escaper->escapeHtmlAttr($item->getLabel())?>"
+                               tabindex="0"
+                               aria-labelledby="<?= $escaper->escapeHtmlAttr($item->getFilter()->getUrlKey()) ?> <?= $escaper->escapeHtmlAttr($cssId) ?>"
                         >
 
                         <label for="<?= $escaper->escapeHtmlAttr($cssId)?>">
@@ -74,7 +78,7 @@ $shouldDisplayProductCountLayer = $block->shouldDisplayProductCountOnLayer();
     </ol>
 
     <?php if ($hasHiddenItems): ?>
-        <a class="more-items"><?=$escaper->escapeHtml(__($block->getMoreItemText()))?></a>
-        <a class="less-items default-hidden"><?=$escaper->escapeHtml(__($block->getLessItemText()))?></a>
+        <a role="button" tabindex="0" class="more-items"><?=$escaper->escapeHtml(__($block->getMoreItemText()))?></a>
+        <a role="button" tabindex="0" class="less-items default-hidden"><?=$escaper->escapeHtml(__($block->getLessItemText()))?></a>
     <?php endif; ?>
 </div>

--- a/view/frontend/templates/product/layered/link.phtml
+++ b/view/frontend/templates/product/layered/link.phtml
@@ -23,8 +23,8 @@ $hasHiddenItems = $block->hasHiddenItems();
     </ol>
 
     <?php if ($hasHiddenItems): ?>
-        <a class="more-items"><?=$escaper->escapeHtml(__($block->getMoreItemText()))?></a>
-        <a class="less-items default-hidden"><?=$escaper->escapeHtml(__($block->getLessItemText()))?></a>
+        <a tabindex="0" role="button" class="more-items"><?=$escaper->escapeHtml(__($block->getMoreItemText()))?></a>
+        <a tabindex="0" role="button" class="less-items default-hidden"><?=$escaper->escapeHtml(__($block->getLessItemText()))?></a>
     <?php endif; ?>
 </div>
 

--- a/view/frontend/templates/product/layered/link/item.phtml
+++ b/view/frontend/templates/product/layered/link/item.phtml
@@ -22,7 +22,12 @@ $hasAlternateSortOrder = $block->hasAlternateSortOrder();
         data-alternate-sort="<?= $escaper->escapeHtmlAttr($item->getAlternateSortOrder());?>"
     <?php endif;?>
 >
-    <a href="<?=$escaper->escapeUrl($block->getCategoryUrl($item))?>">
+    <a
+        id ="<?= $escaper->escapeHtmlAttr($item->getCssId()) ?>"
+        tabindex="0"
+        href="<?=$escaper->escapeUrl($block->getCategoryUrl($item))?>"
+        aria-labelledby="<?= $escaper->escapeHtmlAttr($item->getFilter()->getUrlKey()) ?> <?= $escaper->escapeHtmlAttr($item->getCssId()) ?>"
+    >
         <?=$escaper->escapeHtmlAttr($block->getItemPrefix())?>
         <?=$escaper->escapeHtml($item->getLabel())?>
         <?=$escaper->escapeHtmlAttr($block->getItemPostfix())?>

--- a/view/frontend/templates/product/layered/slider.phtml
+++ b/view/frontend/templates/product/layered/slider.phtml
@@ -41,7 +41,7 @@ $clickpointCounter = 0;
                 $bucketHeight = floor($bucket['relativeamount'] * $bucketHightFactor);
                 $bucketWidth = (($rangeMax - $rangeMin) / $totalRange) * 100;
                 ?>
-                <a href="javascript:void(0);" class="bucket-link" style="width: <?= $escaper->escapeHtmlAttr($bucketWidth) ?>%" data-rangemin="<?= $escaper->escapeHtmlAttr($rangeMin) ?>" data-rangemax="<?= $escaper->escapeHtmlAttr($rangeMax) ?>">
+                <a tabindex="-1" href="javascript:void(0);" class="bucket-link" style="width: <?= $escaper->escapeHtmlAttr($bucketWidth) ?>%" data-rangemin="<?= $escaper->escapeHtmlAttr($rangeMin) ?>" data-rangemax="<?= $escaper->escapeHtmlAttr($rangeMax) ?>">
                     <div class="bucket-range" style="height: <?= $escaper->escapeHtmlAttr($bucketHeight) ?>px;">
                     </div>
                 </a>
@@ -90,6 +90,7 @@ $clickpointCounter = 0;
                    id="<?= $escaper->escapeHtmlAttr($urlKey) ?>-min"
                    name="<?= $escaper->escapeHtmlAttr($urlKey) ?>-min"
                    value="<?= $escaper->escapeHtmlAttr($currentMinValue) ?>"
+                   aria-label="<?= $escaper->escapeHtmlAttr(__('Minimum value')) ?>"
             >
         </div>
         <div class="slider-max-wrapper">
@@ -99,6 +100,7 @@ $clickpointCounter = 0;
                    id="<?= $escaper->escapeHtmlAttr($urlKey) ?>-max"
                    name="<?= $escaper->escapeHtmlAttr($urlKey) ?>-max"
                    value="<?= $escaper->escapeHtmlAttr($currentMaxValue) ?>"
+                   aria-label="<?= $escaper->escapeHtmlAttr(__('Maximum value')) ?>"
             >
         </div>
         <input type="hidden"

--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -20,7 +20,7 @@ $hasHiddenItems = $block->hasHiddenItems();
      attribute-id="<?= $escaper->escapeHtmlAttr($swatchData['attribute_id']) ?>"
      data-mage-init='{"tweakwiseNavigationSort":[]}'>
     <?php if ($block->isSearchable()): ?>
-        <input data-max-visible="<?= $escaper->escapeHtmlAttr($block->getMaxItemsShown())?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $escaper->escapeHtmlAttr($block->getSearchPlaceholder()); ?>" >
+        <input tabindex="-1" data-max-visible="<?= $escaper->escapeHtmlAttr($block->getMaxItemsShown())?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $escaper->escapeHtmlAttr($block->getSearchPlaceholder()); ?>" >
         <div style="display: none" class="search_no_results"><?= $escaper->escapeHtmlAttr($block->getSearchNoResultsText()); ?></div>
     <?php endif; ?>
     <div class="swatch-attribute-options clearfix">
@@ -28,7 +28,9 @@ $hasHiddenItems = $block->hasHiddenItems();
             <?php $item = $block->getItemForSwatch($option);?>
             <?php if (!$item) continue; ?>
             <a <?= /* @noEscape */ $block->renderAnchorHtmlTagAttributes($item);?>
-                aria-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
+                tabindex="0"
+                role="button"
+                aria-labelledby="<?= $escaper->escapeHtmlAttr($item->getFilter()->getUrlKey()) ?> <?= $escaper->escapeHtmlAttr($item->getCssId()) ?>"
                 class="swatch-option-link-layered <?php /* @noEscape */ if ($block->shouldDisplayProductCountOnLayer()): ?>swatch-with-count<?php endif; ?><?= /* @noEscape */ $block->itemDefaultHidden($item) ? ' default-hidden' : ''?>"
             >
                 <?php $cssId = $item->getCssId();?>
@@ -37,7 +39,7 @@ $hasHiddenItems = $block->hasHiddenItems();
                        type="checkbox" <?=/* @noEscape */ ($item->isSelected() ? 'checked="checked"' : '')?>
                        value="<?=$escaper->escapeHtmlAttr($item->getLabel())?>"
                 >
-                <label for="<?=$escaper->escapeHtmlAttr($cssId)?>">
+                <label aria-label="<?= $escaper->escapeHtmlAttr($label['label']); ?>" for="<?= $escaper->escapeHtmlAttr($cssId) ?>">
                 <?php if (isset($swatchData['swatches'][$option]['type'])) { ?>
                     <?php switch ($swatchData['swatches'][$option]['type']) {
                         case '3':


### PR DESCRIPTION
Improved the keyboard interaction and naming voor screenreaders for the filters.

How to test: Use an screensreader (or voice over utility on an mac) and interact with the filters. You should be able to interact with the filters with keyboard only, and the screenreader should have the correct naming for which filters you are on