### PR TITLE
fix: multiple recommendations groups not working

### DIFF
--- a/Model/Client/Response/RecommendationsResponse.php
+++ b/Model/Client/Response/RecommendationsResponse.php
@@ -52,8 +52,13 @@ class RecommendationsResponse extends Response
         if (!empty($recommendation) && !isset($recommendation['items'])) {
             // In this case multiple recommendations are given (group code)
             $recommendations = $recommendation;
+            $items = [];
             foreach ($recommendations as $recommendationEntry) {
-                $this->setData($recommendationEntry);
+                $items[] = $recommendationEntry['items']['item'];
+            }
+
+            if (!empty($items)) {
+                $this->setValue('items', $items);
             }
 
             return;

--- a/Model/Client/Response/RecommendationsResponse.php
+++ b/Model/Client/Response/RecommendationsResponse.php
@@ -54,11 +54,20 @@ class RecommendationsResponse extends Response
             $recommendations = $recommendation;
             $items = [];
             foreach ($recommendations as $recommendationEntry) {
-                $items[] = $recommendationEntry['items']['item'];
+                $this->setData($recommendationEntry);
+                $currentItems = $this->data['items'] ?? [];
+
+                foreach ($currentItems as $currentItem) {
+                    if (isset($items[$currentItem->getId()])) {
+                        continue;
+                    }
+
+                    $items[$currentItem->getId()] = $currentItem;
+                }
             }
 
             if (!empty($items)) {
-                $this->setValue('items', $items);
+                $this->data['items'] = $items;
             }
 
             return;


### PR DESCRIPTION
When multiple recommodation groups are returned, items are overwritten in loop resulting in 1 item based on worst priority. Use all group items and merge them