### PR TITLE
fix: Correct RecommendationsResponse to return empty array if no items are set and Grouped Products is disabled

### DIFF
--- a/Model/Client/Response/RecommendationsResponse.php
+++ b/Model/Client/Response/RecommendationsResponse.php
@@ -67,11 +67,12 @@ class RecommendationsResponse extends Response
      */
     public function getItems(): array
     {
+        if (!$this->hasValue('items')) {
+            return [];
+        }
+        
         if ($this->config->isGroupedProductsEnabled() && !$this->proccessedGroupedProducts) {
             // Manually group items since recommendations doesn't have a grouped call yet.
-            if (!$this->hasValue('items')) {
-                return [];
-            }
 
             // @phpstan-ignore-next-line
             $items = parent::getItems();


### PR DESCRIPTION
In PR #320, @jansentjeu introduced a patch fixing RecommendationsResponse::getItems() not returning a value when no items were set in the Response.

That patch only checked if items were set if Grouped Products were also enabled; leaving an opportunity for `$this->data['items']` to still be unset at the end of this function; resulting in a TypeError.

This patch pulls up the `$this->hasValue('items')` check, so `getItems()` will now return an empty array if no items are present, also if Grouped Products have been disabled (or they're already processed) 