### PR TITLE
fix: grouped products for events

### DIFF
--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -10,6 +10,7 @@
 namespace Tweakwise\Magento2Tweakwise\Model\Catalog\Product;
 
 use Exception;
+use Magento\Catalog\Model\Product\Type;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 use Tweakwise\Magento2Tweakwise\Model\Enum\ItemType;
@@ -184,21 +185,25 @@ class Collection extends AbstractCollection
      */
     protected function applyProductImages(): AbstractCollection
     {
-        foreach ($this->getProductImages() as $productId => $productImageUrl) {
+        foreach ($this->getProductData() as $productId => $data) {
             if (
                 !isset($this->_items[$productId]) ||
-                $this->_items[$productId]->getTypeId() !== Configurable::TYPE_CODE
+                $this->_items[$productId]->getTypeId() === Type::TYPE_SIMPLE
             ) {
                 continue;
             }
 
-            if (empty($productImageUrl)) {
+            if (!empty($data['tw_id'])) {
+                $this->_items[$productId]->setData('tw_id', $data['tw_id']);
+            }
+
+            if (empty($data['image']) || $this->_items[$productId]->getTypeId() !== Configurable::TYPE_CODE) {
                 continue;
             }
 
-            $this->_items[$productId]->setData('image', $productImageUrl);
-            $this->_items[$productId]->setData('small_image', $productImageUrl);
-            $this->_items[$productId]->setData('thumbnail', $productImageUrl);
+            $this->_items[$productId]->setData('image', $data['image']);
+            $this->_items[$productId]->setData('small_image', $data['image']);
+            $this->_items[$productId]->setData('thumbnail', $data['image']);
         }
 
         return $this;
@@ -249,7 +254,7 @@ class Collection extends AbstractCollection
     /**
      * @return array
      */
-    protected function getProductImages(): array
+    protected function getProductData(): array
     {
         try {
             $response = $this->navigationContext->getResponse();
@@ -258,6 +263,6 @@ class Collection extends AbstractCollection
         }
 
         // @phpstan-ignore-next-line
-        return $response->getProductImages() ?? [];
+        return $response->getProductData() ?? [];
     }
 }

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -69,8 +69,8 @@ class Response extends Type
                 $configurable['type'] = $simple['type'];
             }
 
-            if(!empty($simple['itemno'])) {
-                $configurable['tw_id'] = (int)\substr($simple['itemno'], 5);
+            if (!empty($simple['itemno'])) {
+                $configurable['tw_id'] = (int)substr($simple['itemno'], 5);
             }
 
             $items[] = $configurable;

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -69,6 +69,10 @@ class Response extends Type
                 $configurable['type'] = $simple['type'];
             }
 
+            if(!empty($simple['itemno'])) {
+                $configurable['tw_id'] = (int)\substr($simple['itemno'], 5);
+            }
+
             $items[] = $configurable;
         }
 

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -89,20 +89,27 @@ class ProductNavigationResponse extends Response
     /**
      * @return array
      */
-    public function getProductImages(): array
+    public function getProductData(): array
     {
-        $productImages = [];
+        $productData = [];
         // @phpstan-ignore-next-line
         foreach ($this->getItems() as $item) {
-            if (!$item->getImage()) {
-                continue;
+            $data = [];
+            if ($item->getImage()) {
+                // Remove domain and media path when full url is used
+                $imageUrl = preg_replace('#^.*?/catalog/product/#', '', $item->getImage());
+                $data['image'] = $imageUrl;
             }
 
-            // Remove domain and media path when full url is used
-            $imageUrl = preg_replace('#^.*?/catalog/product/#', '', $item->getImage());
-            $productImages[$this->helper->getStoreId($item->getId())] = $imageUrl;
+            $twId = $item->getDataValue('tw_id');
+
+            if (!empty($twId)) {
+                $data['tw_id'] = $twId;
+            }
+
+            $productData[$this->helper->getStoreId($item->getId())] = $data;
         }
 
-        return $productImages;
+        return $productData;
     }
 }

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -133,7 +133,7 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
                     : 'path',
                 'twRequestId' => $this->currentNavigationContext->getTweakwiseRequestId(),
                 'analyticsEvents' => $this->config->isAnalyticsEnabled(),
-                'productSelector' => '.product-item-info',
+                'productSelector' => 'product-item-info',
                 'analyticsEndpoint' => $this->getAnalyticsEndPoint(),
             ],
         ];

--- a/Observer/Event/SendAddToCartEvent.php
+++ b/Observer/Event/SendAddToCartEvent.php
@@ -74,7 +74,14 @@ class SendAddToCartEvent implements ObserverInterface
 
         $tweakwiseRequest = $this->requestFactory->create();
         $totalAmount = $quoteItem->getQtyToAdd() * $product->getPriceModel()->getFinalPrice($quoteItem->getQtyToAdd(), $product);
-        $selectedOption = array_key_first($quoteItem->getQtyOptions());
+
+        $productId = $quoteItem->getProductId();
+
+        if ($this->config->isGroupedProductsEnabled()) {
+            if (!empty($quoteItem->getQtyOptions())) {
+                $productId = array_key_first($quoteItem->getQtyOptions());
+            }
+        }
 
         $tweakwiseRequest->setProfileKey($this->config->getProfileKey());
         $tweakwiseRequest->setParameter('SessionKey', $this->eventService->getSessionKey());
@@ -82,7 +89,7 @@ class SendAddToCartEvent implements ObserverInterface
             'ProductKey',
             $this->helper->getTweakwiseId(
                 (int)$this->storeManager->getStore()->getId(),
-                (int)$selectedOption
+                (int)$productId
             )
         );
         $tweakwiseRequest->setParameter('Quantity', (string)$quoteItem->getQtyToAdd());

--- a/Observer/Event/SendAddToCartEvent.php
+++ b/Observer/Event/SendAddToCartEvent.php
@@ -74,14 +74,15 @@ class SendAddToCartEvent implements ObserverInterface
 
         $tweakwiseRequest = $this->requestFactory->create();
         $totalAmount = $quoteItem->getQtyToAdd() * $product->getPriceModel()->getFinalPrice($quoteItem->getQtyToAdd(), $product);
+        $selectedOption = array_key_first($quoteItem->getQtyOptions());
 
-        $tweakwiseRequest->setParameter('ProfileKey', $this->config->getProfileKey());
+        $tweakwiseRequest->setProfileKey($this->config->getProfileKey());
         $tweakwiseRequest->setParameter('SessionKey', $this->eventService->getSessionKey());
         $tweakwiseRequest->setParameter(
             'ProductKey',
             $this->helper->getTweakwiseId(
                 (int)$this->storeManager->getStore()->getId(),
-                (int)$quoteItem->getProductId()
+                (int)$selectedOption
             )
         );
         $tweakwiseRequest->setParameter('Quantity', (string)$quoteItem->getQtyToAdd());

--- a/Observer/Event/SendAddToWishlistEvent.php
+++ b/Observer/Event/SendAddToWishlistEvent.php
@@ -69,14 +69,23 @@ class SendAddToWishlistEvent implements ObserverInterface
             return;
         }
 
+        $productId = (int)$product->getId();
+
+        if ($this->config->isGroupedProductsEnabled()) {
+            $children = $product->getExtensionAttributes()->getConfigurableProductLinks();
+            if (!empty($children)) {
+                $productId = (int)array_first($children);
+            }
+        }
+
         $tweakwiseRequest = $this->requestFactory->create();
-        $tweakwiseRequest->setParameter('ProfileKey', $this->config->getProfileKey());
+        $tweakwiseRequest->setProfileKey($this->config->getProfileKey());
         $tweakwiseRequest->setParameter('SessionKey', $this->eventService->getSessionKey());
         $tweakwiseRequest->setParameter(
             'ProductKey',
             $this->helper->getTweakwiseId(
                 (int)$this->storeManager->getStore()->getId(),
-                (int)$product->getId()
+                $productId
             )
         );
         $tweakwiseRequest->setPath('addtowishlist');

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -68,13 +68,25 @@ class TweakwiseCheckout implements ObserverInterface
         $tweakwiseRequest = $this->requestFactory->create();
 
         $tweakwiseRequest->setParameter('SessionKey', $this->eventService->getSessionKey());
-        $tweakwiseRequest->setParameter('ProfileKey', $profileKey);
+        $tweakwiseRequest->setProfileKey($profileKey);
         $tweakwiseRequest->setParameter('Revenue', (string)$totalExclTax);
         $tweakwiseRequest->setPath('purchase');
 
+        if ($this->config->isGroupedProductsEnabled()) {
+            $items = array_filter(
+                $items,
+                fn($item) => $item->getParentItem() !== null
+            );
+        } else {
+            $items = array_filter(
+                $items,
+                fn($item) => $item->getParentItem() === null
+            );
+        }
+
         // @phpstan-ignore-next-line
         foreach ($items as $item) {
-            $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+            $productTwId[(int)$item->getProductId()] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
         }
 
         // @phpstan-ignore-next-line

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -37,7 +37,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
         private readonly StoreManagerInterface $storeManager,
         private readonly RequestInterface $request,
         private readonly Json $jsonSerializer,
-        private readonly ProductRepositoryInterface $product,
+        private readonly ProductRepositoryInterface $productRepository,
     ) {
     }
 
@@ -59,8 +59,19 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
             return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
         }
 
+        return $this->getGroupedProductId((int)$productId, (int)$storeId);
+    }
+
+    /**
+     * Get the grouped product ID.
+     *
+     * @param int $productId
+     * @param int $storeId
+     * @return int
+     */
+    private function getGroupedProductId(int $productId, int $storeId): int{
         try {
-            $product = $this->product->getById($productId);
+            $product = $this->productRepository->getById($productId);
             if ($product->getTypeId() === Type::TYPE_SIMPLE) {
                 return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
             }

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -61,7 +61,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
 
         try {
             $product = $this->product->getById($productId);
-            if ($product->getTypeId() == Type::TYPE_SIMPLE) {
+            if ($product->getTypeId() === Type::TYPE_SIMPLE) {
                 return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
             }
 
@@ -79,7 +79,6 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
                 $firstAssociatedProduct = reset($associatedProducts);
                 $productId = $firstAssociatedProduct->getId();
             }
-
         } catch (NoSuchEntityException $e) {
             // Do nothing
         }

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Tweakwise\Magento2Tweakwise\ViewModel;
 
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Tweakwise\Magento2Tweakwise\Model\Config;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\RequestInterface;
+use Magento\Catalog\Model\Product\Type;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Class PersonalMerchandisingAnalytics
@@ -24,6 +29,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
      * @param StoreManagerInterface $storeManager
      * @param RequestInterface $request
      * @param Json $jsonSerializer
+     * @param ProductRepositoryInterface $product
      */
     public function __construct(
         private readonly Config $tweakwiseConfig,
@@ -31,6 +37,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
         private readonly StoreManagerInterface $storeManager,
         private readonly RequestInterface $request,
         private readonly Json $jsonSerializer,
+        private readonly ProductRepositoryInterface $product,
     ) {
     }
 
@@ -46,6 +53,35 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
 
         if (!$productId) {
             return '0';
+        }
+
+        if (!$this->tweakwiseConfig->isGroupedProductsEnabled()) {
+            return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+        }
+
+        try {
+            $product = $this->product->getById($productId);
+            if ($product->getTypeId() == Type::TYPE_SIMPLE) {
+                return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+            }
+
+            match ($product->getTypeId()) {
+                Configurable::TYPE_CODE => $associatedProducts = $product->getTypeInstance()->getUsedProducts($product),
+                Grouped::TYPE_CODE => $associatedProducts = $product->getTypeInstance()->getAssociatedProducts($product),
+                Type::TYPE_BUNDLE => $associatedProducts = $product->getTypeInstance()->getSelectionsCollection(
+                    $product->getTypeInstance()->getOptionsIds($product),
+                    $product
+                ),
+                default => $associatedProducts = [],
+            };
+
+            if (!empty($associatedProducts)) {
+                $firstAssociatedProduct = reset($associatedProducts);
+                $productId = $firstAssociatedProduct->getId();
+            }
+
+        } catch (NoSuchEntityException $e) {
+            // Do nothing
         }
 
         return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -69,7 +69,8 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
      * @param int $storeId
      * @return int
      */
-    private function getGroupedProductId(int $productId, int $storeId): int{
+    private function getGroupedProductId(int $productId, int $storeId): int
+    {
         try {
             $product = $this->productRepository->getById($productId);
             if ($product->getTypeId() === Type::TYPE_SIMPLE) {

--- a/view/frontend/templates/product/list/item.phtml
+++ b/view/frontend/templates/product/list/item.phtml
@@ -24,10 +24,11 @@ $pos = $block->getData('pos');
 $_helper = $block->getData('output_helper');
 $templateType = $block->getData('template_type');
 $showDescription = $block->getData('show_description');
+$productId = $_product->getData('tw_id') ?: $_product->getId();
 ?>
 <li class="item product product-item">
     <div class="product-item-info"
-         id="product-item-info_<?=  $escaper->escapeHtmlAttr($_product->getId()) ?>"
+         id="product-item-info_<?=  $escaper->escapeHtmlAttr($productId) ?>"
          data-container="product-<?=  $escaper->escapeHtmlAttr($viewMode) ?>">
         <?php
         $productImage = $block->getImage($_product, $imageDisplayArea);

--- a/view/frontend/web/js/analytics.js
+++ b/view/frontend/web/js/analytics.js
@@ -7,7 +7,7 @@ define('Tweakwise_Magento2Tweakwise/js/analytics', ['jquery'], function($) {
                 return;
             }
 
-            const product = $(event.target).closest(`${config.productSelector}`)[0];
+            const product = $(event.target).closest(`.${config.productSelector}`)[0];
             let productId;
 
             if (!product || !product.id) {

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -29,7 +29,7 @@ define([
             urlStrategy: '',
             twRequestId: '',
             analyticsEvents: false,
-            productSelector: '.product-item-info',
+            productSelector: 'product-item-info',
             analyticsEndpoint: '/tweakwise/ajax/analytics',
         },
 


### PR DESCRIPTION
How to test.

Trigger the following events, and see if the product/item id send to tweakwise is correct and an item in tweakwise

Test the following events

- Purchase event
- Itemclick event
- Pageview event (pdp)
- Add to cart event
- Add to whishlist event

With the following settings

- Grouped export/grouped products enabled (make sure to dan an full export and import in TW)
- Test an configurble product and an simple product.

For the add to whishlist and pageview events, the selected variant is not known (if it is not an simple product) and the first variant of an item is used.




