### PR TITLE
fix: visuals in grouped product should have url

### DIFF
--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -67,6 +67,10 @@ class Response extends Type
 
             if (!empty($simple['type'])) {
                 $configurable['type'] = $simple['type'];
+                // Add visual url to visual item
+                if ($simple['type'] === 'visual') {
+                    $configurable['url'] = $simple['url'];
+                }
             }
 
             $items[] = $configurable;


### PR DESCRIPTION
Fixes issue with visuals without url and not clickabel in results