### PR TITLE
Fix: send product array without keys

### DIFF
--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -86,7 +86,7 @@ class TweakwiseCheckout implements ObserverInterface
 
         // @phpstan-ignore-next-line
         foreach ($items as $item) {
-            $productTwId[(int)$item->getProductId()] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+            $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
         }
 
         // @phpstan-ignore-next-line


### PR DESCRIPTION
The checkout event sends the product keys wrong to tweakwise resulting in an 400 bad request response. This fixes the problem by removing the array keys.