### PR TITLE
Fix: trailing slash

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -262,11 +262,16 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
              These two are the only unique parts in this situation and so need to be removed.
              */
 
+            $hadTrailingSlash = substr($url, -1) === '/';
             $explode = explode('/', $url);
 
             // @phpstan-ignore-next-line
             if (is_array($explode)) {
                 $url = implode('/', array_unique($explode));
+
+                if ($hadTrailingSlash && substr($url, -1) !== '/') {
+                    $url .= '/';
+                }
             }
 
             $url = str_replace($this->url->getBaseUrl(), '', $url);


### PR DESCRIPTION
Fixed an issue with the trailing slash missing of the category url's

How to test

- Enable query parameters for the url stategy. 
- Have an slash as the seo category url suffix

Expected result

The category url's in the category filter end with an slash
