### PR TITLE
Fix: visibility grouped products

### DIFF
--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -177,6 +177,7 @@ class Collection extends AbstractCollection
         $this->applyCollectionSizeValues();
         $this->enrichProducts();
         $this->addVisuals();
+        $this->removeDuplicatedProducts();
 
         return $this;
     }
@@ -334,5 +335,24 @@ class Collection extends AbstractCollection
 
         // @phpstan-ignore-next-line
         return $response->getProductData() ?? [];
+    }
+
+    /**
+     * @return void
+     */
+    protected function removeDuplicatedProducts(): void
+    {
+        if ($this->config->isGroupedProductsEnabled()) {
+            foreach ($this->_items as $key => $item) {
+                if (!$item instanceof ProductInterface) {
+                    continue;
+                }
+
+                $twId = (int)$item->getData('tw_id') ?? '0';
+                if (isset($this->_items[$twId]) && $key !== $twId) {
+                    unset($this->_items[$twId]);
+                }
+            }
+        }
     }
 }

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -342,16 +342,18 @@ class Collection extends AbstractCollection
      */
     protected function removeDuplicatedProducts(): void
     {
-        if ($this->config->isGroupedProductsEnabled()) {
-            foreach ($this->_items as $key => $item) {
-                if (!$item instanceof ProductInterface) {
-                    continue;
-                }
+        if (!$this->config->isGroupedProductsEnabled()) {
+            return;
+        }
 
-                $twId = (int)$item->getData('tw_id') ?? '0';
-                if (isset($this->_items[$twId]) && $key !== $twId) {
-                    unset($this->_items[$twId]);
-                }
+        foreach ($this->_items as $key => $item) {
+            if (!$item instanceof ProductInterface) {
+                continue;
+            }
+
+            $twId = (int)$item->getData('tw_id') ?? '0';
+            if (isset($this->_items[$twId]) && $key !== $twId) {
+                unset($this->_items[$twId]);
             }
         }
     }

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -352,9 +352,11 @@ class Collection extends AbstractCollection
             }
 
             $twId = (int)$item->getData('tw_id') ?? '0';
-            if (isset($this->_items[$twId]) && $key !== $twId) {
-                unset($this->_items[$twId]);
+            if (!isset($this->_items[$twId]) || $key === $twId) {
+                continue;
             }
+
+            unset($this->_items[$twId]);
         }
     }
 }

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -79,9 +79,10 @@ class Response extends Type
             }
 
             $items[] = $configurable;
-            if ($simple['type'] === 'product') {
-                $items[] = $simple;
+            if ($simple['type'] !== 'product') {
+                continue;
             }
+            $items[] = $simple;
         }
 
         $this->setItems($items);

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -58,6 +58,7 @@ class Response extends Type
             $configurable = $this->getConfigurable($group);
 
             if (!$configurable) {
+                $items[] = $simple;
                 continue;
             }
 
@@ -78,6 +79,9 @@ class Response extends Type
             }
 
             $items[] = $configurable;
+            if ($simple['type'] === 'product') {
+                $items[] = $simple;
+            }
         }
 
         $this->setItems($items);


### PR DESCRIPTION
This pull request fixes the following issues with grouped products and visibility

### Current Situation
When grouped products are enabled, Tweakwise results may include products that should either be displayed individually or as part of a parent product (Configurable/Group/Bundle).

### Example Scenario:

Parent: A configurable T-shirt (various colors/sizes) set to be visible only in the Catalog, not in Search.

Child: A specific simple product (Red T-shirt, Size XL) set to be visible only in Search.

Currently, the system always attempts to display the parent (Configurable/Group/Bundle). Because the parent's visibility settings forbid it from appearing in search, the product is filtered out entirely, leading to "empty spots" or missing results in the search interface even when a valid child product exists.

### Desired Situation

The child product should be visible in the search, the configurable in the catalog.

### Solution

When grouped products is enabled the result that is passed on to magento contains both the simple and the configurable product. Magento itself filters out if the simple or configurable is not visible. And after that, we remove any remaining duplicate products. We remove the simple product if the configurable is shown. This prevents issues with the pagination as tweakwise only returns one product, so only one should be shown. For example when an configurable and an simple is visible in the catalog.

### How to test

This pull request needs to be tested with the fix in the tweakwise export to ensure the parent visibility in tweakwise is correct. https://github.com/EmicoEcommerce/Magento2TweakwiseExport/pull/135.
Make sure that grouped export is enabled and that the magento indexer is run after changing products.

**1. The "Search" Visibility Test (The Core Fix)**
Verifies that the Child product correctly surfaces when the Parent is restricted.

Setup: * Configurable Parent: Visibility = Catalog only.

Simple Child: Visibility = Search only.

Action: Search for the specific Child SKU.

Expected Result: * The Child product appears; the Parent does not.

The amount of products shown is correct, and the pagination is correct (e.g., "1 Item" displayed in toolbar, 1 card rendered).

**2. The "Catalog" Visibility Test (Deduplication)**
Ensures that when both are eligible for a category, we show the Parent to represent the group.

Setup:

Configurable Parent: Visibility = Catalog, Search.

Simple Child: Visibility = Catalog, Search.

Action: Navigate to the Category page.

Expected Result: * Only the Configurable Parent is visible.

The amount of products shown is correct, and the pagination is correct (Count matches unique parent entities).

**3. Multiple Visible Children (The "Both Simples" Case)**
Verifies that if multiple children are explicitly set to be visible in Search, the system does not deduplicate them into a single entry.

Setup: * Configurable Parent: Visibility = Catalog only.

Simple Child A (Red): Visibility = Search only.

Simple Child B (Blue): Visibility = Search only.

Action: Search for the product name (e.g., "T-shirt").

Expected Result: * Both Simple products (Red and Blue) are displayed individually.

The amount of products shown is correct, and the pagination is correct (e.g., Toolbar shows "2 Items," and 2 separate product cards are rendered).