### PR TITLE
feat: add attribute code to tweakwise slug table

### DIFF
--- a/Console/Command/RegenerateFilterUrlSlugs.php
+++ b/Console/Command/RegenerateFilterUrlSlugs.php
@@ -85,7 +85,11 @@ class RegenerateFilterUrlSlugs extends Command
                             )
                         );
 
-                        $this->regenerateSlugsForAttributeOption($option, (int)$store->getId());
+                        $this->regenerateSlugsForAttributeOption(
+                            $option,
+                            (int)$store->getId(),
+                            (string)$attribute->getAttributeCode()
+                        );
 
                         $counter++;
                     }
@@ -130,10 +134,14 @@ class RegenerateFilterUrlSlugs extends Command
     /**
      * @param Option $option
      * @param int $storeId
+     * @param string|null $attributeCode
      * @return void
      */
-    protected function regenerateSlugsForAttributeOption(Option $option, int $storeId): void
-    {
-        $this->filterSlugManager->createFilterSlugByOption($option, $storeId);
+    protected function regenerateSlugsForAttributeOption(
+        Option $option,
+        int $storeId,
+        ?string $attributeCode = null
+    ): void {
+        $this->filterSlugManager->createFilterSlugByOption($option, $storeId, $attributeCode);
     }
 }

--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -119,6 +119,7 @@ class FilterSlugManager
      */
     public function createFilterSlugByAttributeOptions(Attribute $options)
     {
+        $attributeCode = (string)$options->getAttributeCode();
         $allTranslations = $options->toArray();
         if (!isset($allTranslations['option']['value'])) {
             return;
@@ -146,6 +147,7 @@ class FilterSlugManager
                 $attributeSlugEntity->setAttribute($optionLabel);
                 $attributeSlugEntity->setStoreId((int)$storeId);
                 $attributeSlugEntity->setSlug($this->translitUrl->filter($optionLabel));
+                $attributeSlugEntity->setData('attribute_code', $attributeCode ?: null);
 
                 $this->attributeSlugRepository->save($attributeSlugEntity);
                 $this->cache->remove(self::CACHE_KEY);
@@ -233,9 +235,10 @@ class FilterSlugManager
     /**
      * @param Option $option
      * @param int $storeId
+     * @param string|null $attributeCode
      * @return void
      */
-    public function createFilterSlugByOption(Option $option, int $storeId): void
+    public function createFilterSlugByOption(Option $option, int $storeId, ?string $attributeCode = null): void
     {
         if (empty($this->translitUrl->filter($option['label'])) || ctype_space((string)$option['label'])) {
             return;
@@ -245,6 +248,7 @@ class FilterSlugManager
         $attributeSlugEntity->setAttribute($option['label']);
         $attributeSlugEntity->setStoreId((int)$storeId);
         $attributeSlugEntity->setSlug($this->translitUrl->filter($option['label']));
+        $attributeSlugEntity->setData('attribute_code', $attributeCode ?: null);
         $this->attributeSlugRepository->save($attributeSlugEntity);
     }
 }

--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -142,7 +142,7 @@ class FilterSlugManager
                 $this->saveAttributeSlugForOptionLabel(
                     $normalizedOptionLabel,
                     (int)$storeId,
-                    $attributeCode ?: null,
+                    $attributeCode !== '' ? $attributeCode : null,
                     $slug
                 );
             }

--- a/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
+++ b/Model/Catalog/Layer/Url/Strategy/FilterSlugManager.php
@@ -120,39 +120,99 @@ class FilterSlugManager
     public function createFilterSlugByAttributeOptions(Attribute $options)
     {
         $attributeCode = (string)$options->getAttributeCode();
-        $allTranslations = $options->toArray();
-        if (!isset($allTranslations['option']['value'])) {
+        $optionValueTranslations = $this->getOptionValueTranslations($options);
+        if ($optionValueTranslations === []) {
             return;
         }
-        foreach ($allTranslations['option']['value'] as $optionTranslations) {
+
+        $this->getLookupTable();
+
+        foreach ($optionValueTranslations as $optionTranslations) {
             foreach ($optionTranslations as $storeId => $optionLabel) {
-                if (empty($optionLabel) || ctype_space((string)$optionLabel)) {
+                $normalizedOptionLabel = $this->normalizeOptionLabel($optionLabel);
+                if ($normalizedOptionLabel === null) {
                     continue;
                 }
 
-                $this->getLookupTable();
-                if ($optionLabel instanceof Phrase) {
-                    $optionLabel = $optionLabel->render();
-                }
-
-                if (empty($this->translitUrl->filter($optionLabel))) {
+                $slug = $this->translitUrl->filter($normalizedOptionLabel);
+                if ($this->shouldSkipOptionLabelForStore((int)$storeId, $normalizedOptionLabel, $slug)) {
                     continue;
                 }
 
-                if (isset($this->lookupTable[$storeId][strtolower($optionLabel)])) {
-                    continue;
-                }
-
-                $attributeSlugEntity = $this->attributeSlugFactory->create();
-                $attributeSlugEntity->setAttribute($optionLabel);
-                $attributeSlugEntity->setStoreId((int)$storeId);
-                $attributeSlugEntity->setSlug($this->translitUrl->filter($optionLabel));
-                $attributeSlugEntity->setData('attribute_code', $attributeCode ?: null);
-
-                $this->attributeSlugRepository->save($attributeSlugEntity);
-                $this->cache->remove(self::CACHE_KEY);
+                $this->saveAttributeSlugForOptionLabel(
+                    $normalizedOptionLabel,
+                    (int)$storeId,
+                    $attributeCode ?: null,
+                    $slug
+                );
             }
         }
+    }
+
+    /**
+     * @param Attribute $options
+     * @return array
+     */
+    private function getOptionValueTranslations(Attribute $options): array
+    {
+        $allTranslations = $options->toArray();
+
+        return $allTranslations['option']['value'] ?? [];
+    }
+
+    /**
+     * @param mixed $optionLabel
+     * @return string|null
+     */
+    private function normalizeOptionLabel($optionLabel): ?string
+    {
+        if ($optionLabel instanceof Phrase) {
+            $optionLabel = $optionLabel->render();
+        }
+
+        if (empty($optionLabel) || ctype_space((string)$optionLabel)) {
+            return null;
+        }
+
+        return (string)$optionLabel;
+    }
+
+    /**
+     * @param int $storeId
+     * @param string $optionLabel
+     * @param string $slug
+     * @return bool
+     */
+    private function shouldSkipOptionLabelForStore(int $storeId, string $optionLabel, string $slug): bool
+    {
+        if (empty($slug)) {
+            return true;
+        }
+
+        return isset($this->lookupTable[$storeId][strtolower($optionLabel)]);
+    }
+
+    /**
+     * @param string $optionLabel
+     * @param int $storeId
+     * @param string|null $attributeCode
+     * @param string $slug
+     * @return void
+     */
+    private function saveAttributeSlugForOptionLabel(
+        string $optionLabel,
+        int $storeId,
+        ?string $attributeCode,
+        string $slug
+    ): void {
+        $attributeSlugEntity = $this->attributeSlugFactory->create();
+        $attributeSlugEntity->setAttribute($optionLabel);
+        $attributeSlugEntity->setStoreId($storeId);
+        $attributeSlugEntity->setSlug($slug);
+        $attributeSlugEntity->setData('attribute_code', $attributeCode);
+
+        $this->attributeSlugRepository->save($attributeSlugEntity);
+        $this->cache->remove(self::CACHE_KEY);
     }
 
     /**
@@ -248,7 +308,7 @@ class FilterSlugManager
         $attributeSlugEntity->setAttribute($option['label']);
         $attributeSlugEntity->setStoreId((int)$storeId);
         $attributeSlugEntity->setSlug($this->translitUrl->filter($option['label']));
-        $attributeSlugEntity->setData('attribute_code', $attributeCode ?: null);
+        $attributeSlugEntity->setData('attribute_code', $attributeCode ? $attributeCode : null);
         $this->attributeSlugRepository->save($attributeSlugEntity);
     }
 }

--- a/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
+++ b/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
@@ -10,10 +10,18 @@ use Magento\Framework\Setup\SchemaSetupInterface;
 
 class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterface
 {
+    /**
+     * Constructor.
+     *
+     * @param SchemaSetupInterface $schemaSetup
+     */
     public function __construct(private readonly SchemaSetupInterface $schemaSetup)
     {
     }
 
+    /**
+     * @return $this|AddAttributeCodeToTweakwiseAttributeSlugTable
+     */
     public function apply()
     {
         $setup = $this->schemaSetup;
@@ -39,6 +47,9 @@ class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterf
         return $this;
     }
 
+    /**
+     * @return class-string[]
+     */
     public static function getDependencies()
     {
         return [
@@ -46,6 +57,9 @@ class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterf
         ];
     }
 
+    /**
+     * @return array|string[]
+     */
     public function getAliases()
     {
         return [];

--- a/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
+++ b/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tweakwise\Magento2Tweakwise\Setup\Patch\Schema;
+
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\Patch\SchemaPatchInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterface
+{
+    public function __construct(private readonly SchemaSetupInterface $schemaSetup)
+    {
+    }
+
+    public function apply()
+    {
+        $setup = $this->schemaSetup;
+        $setup->startSetup();
+        $connection = $setup->getConnection();
+        $tableName = $setup->getTable('tweakwise_attribute_slug');
+
+        if ($connection->isTableExists($tableName)
+            && !$connection->tableColumnExists($tableName, 'attribute_code')
+        ) {
+            $connection->addColumn($tableName, 'attribute_code', [
+                'type' => Table::TYPE_TEXT,
+                'length' => 255,
+                'nullable' => true,
+                'default' => null,
+                'comment' => 'Attribute code',
+            ]);
+        }
+
+        $setup->endSetup();
+
+        return $this;
+    }
+
+    public static function getDependencies()
+    {
+        return [
+            ChangePrimaryKeyTweakwiseAttributeSlugTable::class,
+        ];
+    }
+
+    public function getAliases()
+    {
+        return [];
+    }
+}
+

--- a/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
+++ b/Setup/Patch/Schema/AddAttributeCodeToTweakwiseAttributeSlugTable.php
@@ -21,7 +21,8 @@ class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterf
         $connection = $setup->getConnection();
         $tableName = $setup->getTable('tweakwise_attribute_slug');
 
-        if ($connection->isTableExists($tableName)
+        if (
+            $connection->isTableExists($tableName)
             && !$connection->tableColumnExists($tableName, 'attribute_code')
         ) {
             $connection->addColumn($tableName, 'attribute_code', [
@@ -50,4 +51,3 @@ class AddAttributeCodeToTweakwiseAttributeSlugTable implements SchemaPatchInterf
         return [];
     }
 }
-


### PR DESCRIPTION
Add attribute_code to the tweakwise slug table.

How to test

- Run setup upgrade
- Run bin/magento tweakwise:regenerate:filter-url-slugs
- See that the attribute code field is filled in the tweakwise_attribute_slug_table