### PR TITLE
fix: Made route parameter nullable

### DIFF
--- a/Block/Theme/Html/Pager/Plugin.php
+++ b/Block/Theme/Html/Pager/Plugin.php
@@ -41,11 +41,11 @@ class Plugin
     /**
      * @param Pager $subject
      * @param Closure $proceed
-     * @param string $route
+     * @param string|null $route
      * @param array $params
      * @return string
      */
-    public function aroundGetUrl(Pager $subject, Closure $proceed, string $route = '', array $params = []): string
+    public function aroundGetUrl(Pager $subject, Closure $proceed, ?string $route = '', array $params = []): string
     {
         if (!$this->config->isLayeredEnabled()) {
             return $proceed($route, $params);


### PR DESCRIPTION
Fixes the following error:

`Tweakwise\Magento2Tweakwise\Block\Theme\Html\Pager\Plugin::aroundGetUrl(): Argument #3 ($route) must be of type string, null given`

Parent function has no strict type, so it can be nullable.

```
    public function getUrl($route = '', $params = [])
    {
        return $this->_urlBuilder->getUrl($route, $params);
    }
```