### PR TITLE
Fix events for grouped export

### DIFF
--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultInterface;
 use Tweakwise\Magento2Tweakwise\Service\Event\SessionStartEventService;
+use Tweakwise\Magento2Tweakwise\ViewModel\PersonalMerchandisingAnalytics;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Magento\Store\Model\StoreManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request;
@@ -33,6 +34,7 @@ class Analytics extends Action
      * @param StoreManagerInterface $storeManager
      * @param JsonSerializer $jsonSerializer
      * @param SessionStartEventService $sessionStartEventService
+     * @param PersonalMerchandisingAnalytics $personalMerchandisingAnalytics
      */
     public function __construct(
         Context $context,
@@ -44,6 +46,7 @@ class Analytics extends Action
         private readonly StoreManagerInterface $storeManager,
         private readonly JsonSerializer $jsonSerializer,
         private readonly SessionStartEventService $sessionStartEventService,
+        private readonly PersonalMerchandisingAnalytics $personalMerchandisingAnalytics,
     ) {
         parent::__construct($context);
     }
@@ -205,6 +208,11 @@ class Analytics extends Action
         $groupCode = null;
         if (str_contains($itemId, Helper::GROUP_CODE_DELIMITER)) {
             [$itemId, $groupCode] = explode(Helper::GROUP_CODE_DELIMITER, $itemId, 2);
+        } else {
+            $groupedProductId = (string)$this->personalMerchandisingAnalytics->getGroupedProductId((int)$itemId);
+            if (str_contains($groupedProductId, Helper::GROUP_CODE_DELIMITER)) {
+                [$itemId, $groupCode] = explode(Helper::GROUP_CODE_DELIMITER, $groupedProductId, 2);
+            }
         }
 
         $itemTweakwiseId = $this->helper->getTweakwiseId($storeId, (int)$itemId);

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -6,6 +6,7 @@ use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Throwable;
 use Tweakwise\Magento2Tweakwise\Model\Client;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request\AnalyticsRequest;
 use Tweakwise\Magento2Tweakwise\Model\PersonalMerchandisingConfig;
@@ -16,10 +17,10 @@ use Magento\Framework\Controller\ResultInterface;
 use Tweakwise\Magento2Tweakwise\Service\Event\SessionStartEventService;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Magento\Store\Model\StoreManagerInterface;
-use Exception;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request;
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 use InvalidArgumentException;
+use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class Analytics extends Action
 {
@@ -44,6 +45,7 @@ class Analytics extends Action
         private readonly StoreManagerInterface $storeManager,
         private readonly JsonSerializer $jsonSerializer,
         private readonly SessionStartEventService $sessionStartEventService,
+        private readonly Config $tweakwiseConfig,
     ) {
         parent::__construct($context);
     }
@@ -80,7 +82,7 @@ class Analytics extends Action
                 $this->processAnalyticsRequest($eventData);
             }
             return $result->setData(['success' => true]);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return $result->setData(['success' => false, 'message' => $e->getMessage()]);
         }
 
@@ -166,8 +168,6 @@ class Analytics extends Action
      */
     private function handleItemClickType(Request $tweakwiseRequest, string $itemId, ?string $requestId): void
     {
-        $storeId = (int)$this->storeManager->getStore()->getId();
-
         if (empty($requestId)) {
             throw new InvalidArgumentException('Missing requestId for itemclick.');
         }
@@ -192,19 +192,31 @@ class Analytics extends Action
         $tweakwiseRequest->setPath('pageimpression');
     }
 
-    private function getProductKey(string $itemId) {
+    /**
+     * @param string $itemId
+     * @return string
+     */
+    private function getProductKey(string $itemId): string
+    {
+        $storeId = (int)$this->storeManager->getStore()->getId();
+
+        if (!$this->config->isGroupedProductsEnabled($this->storeManager->getStore())) {
+            return $this->helper->getTweakwiseId($storeId, (int)$itemId);
+        }
+
         $groupCode = null;
-        if (strpos($itemId, Helper::GROUP_CODE_DELIMITER) !== false) {
+        if (str_contains($itemId, Helper::GROUP_CODE_DELIMITER)) {
             [$itemId, $groupCode] = explode(Helper::GROUP_CODE_DELIMITER, $itemId, 2);
         }
 
-        if (ctype_digit($itemId)) {
-            if ($groupCode && ctype_digit($groupCode)) {
-                $groupCode = $this->helper->getTweakwiseId($this->storeManager->getStore()->getId(), (int)$groupCode);
-            }
-            $itemId = $this->helper->getTweakwiseId($this->storeManager->getStore()->getId(), (int)$itemId, $groupCode);
+        $itemTweakwiseId = $this->helper->getTweakwiseId($storeId, (int)$itemId);
+
+        if ($groupCode === null || $groupCode === '') {
+            $groupCode = $itemTweakwiseId;
         }
 
-        return $itemId;
+        $groupTweakwiseId = $this->helper->getTweakwiseId($storeId, (int)$groupCode);
+
+        return $itemTweakwiseId . Helper::GROUP_CODE_DELIMITER . $groupTweakwiseId;
     }
 }

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -137,6 +137,8 @@ class Analytics extends Action
      */
     private function handleProductType(Request $tweakwiseRequest, string $productKey): void
     {
+        $productKey = $this->getProductKey($productKey);
+
         $tweakwiseRequest->setParameter('SessionKey', $this->sessionStartEventService->getSessionKey());
         $tweakwiseRequest->setParameter('ProductKey', $productKey);
         $tweakwiseRequest->setPath('pageview');
@@ -170,10 +172,7 @@ class Analytics extends Action
             throw new InvalidArgumentException('Missing requestId for itemclick.');
         }
 
-        if (ctype_digit($itemId)) {
-            // @phpstan-ignore-next-line
-            $itemId = $this->helper->getTweakwiseId($storeId, $itemId);
-        }
+        $itemId = $this->getProductKey($itemId);
 
         $tweakwiseRequest->setParameter('SessionKey', $this->sessionStartEventService->getSessionKey());
         $tweakwiseRequest->setParameter('RequestId', $requestId);
@@ -191,5 +190,21 @@ class Analytics extends Action
         $tweakwiseRequest->setParameter('SessionKey', $this->sessionStartEventService->getSessionKey());
         $tweakwiseRequest->setParameter('RequestId', $requestId);
         $tweakwiseRequest->setPath('pageimpression');
+    }
+
+    private function getProductKey(string $itemId) {
+        $groupCode = null;
+        if (strpos($itemId, Helper::GROUP_CODE_DELIMITER) !== false) {
+            [$itemId, $groupCode] = explode(Helper::GROUP_CODE_DELIMITER, $itemId, 2);
+        }
+
+        if (ctype_digit($itemId)) {
+            if ($groupCode && ctype_digit($groupCode)) {
+                $groupCode = $this->helper->getTweakwiseId($this->storeManager->getStore()->getId(), (int)$groupCode);
+            }
+            $itemId = $this->helper->getTweakwiseId($this->storeManager->getStore()->getId(), (int)$itemId, $groupCode);
+        }
+
+        return $itemId;
     }
 }

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -17,7 +17,6 @@ use Magento\Framework\Controller\ResultInterface;
 use Tweakwise\Magento2Tweakwise\Service\Event\SessionStartEventService;
 use Tweakwise\Magento2Tweakwise\ViewModel\PersonalMerchandisingAnalytics;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
-use Magento\Store\Model\StoreManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request;
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 use InvalidArgumentException;

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -20,7 +20,6 @@ use Magento\Store\Model\StoreManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Client\Request;
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 use InvalidArgumentException;
-use Tweakwise\Magento2Tweakwise\Model\Config;
 
 class Analytics extends Action
 {
@@ -45,7 +44,6 @@ class Analytics extends Action
         private readonly StoreManagerInterface $storeManager,
         private readonly JsonSerializer $jsonSerializer,
         private readonly SessionStartEventService $sessionStartEventService,
-        private readonly Config $tweakwiseConfig,
     ) {
         parent::__construct($context);
     }

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -31,7 +31,6 @@ class Analytics extends Action
      * @param PersonalMerchandisingConfig $config
      * @param RequestFactory $requestFactory
      * @param Helper $helper
-     * @param StoreManagerInterface $storeManager
      * @param JsonSerializer $jsonSerializer
      * @param SessionStartEventService $sessionStartEventService
      * @param PersonalMerchandisingAnalytics $personalMerchandisingAnalytics
@@ -43,7 +42,6 @@ class Analytics extends Action
         private PersonalMerchandisingConfig $config,
         private readonly RequestFactory $requestFactory,
         private readonly Helper $helper,
-        private readonly StoreManagerInterface $storeManager,
         private readonly JsonSerializer $jsonSerializer,
         private readonly SessionStartEventService $sessionStartEventService,
         private readonly PersonalMerchandisingAnalytics $personalMerchandisingAnalytics,
@@ -199,9 +197,9 @@ class Analytics extends Action
      */
     private function getProductKey(string $itemId): string
     {
-        $storeId = (int)$this->storeManager->getStore()->getId();
+        $storeId = (int)$this->personalMerchandisingAnalytics->storeManager->getStore()->getId();
 
-        if (!$this->config->isGroupedProductsEnabled($this->storeManager->getStore())) {
+        if (!$this->config->isGroupedProductsEnabled($this->personalMerchandisingAnalytics->storeManager->getStore())) {
             return $this->helper->getTweakwiseId($storeId, (int)$itemId);
         }
 

--- a/Controller/Ajax/Analytics.php
+++ b/Controller/Ajax/Analytics.php
@@ -196,9 +196,9 @@ class Analytics extends Action
      */
     private function getProductKey(string $itemId): string
     {
-        $storeId = (int)$this->personalMerchandisingAnalytics->storeManager->getStore()->getId();
+        $storeId = (int)$this->personalMerchandisingAnalytics->getStoreManager()->getStore()->getId();
 
-        if (!$this->config->isGroupedProductsEnabled($this->personalMerchandisingAnalytics->storeManager->getStore())) {
+        if (!$this->config->isGroupedProductsEnabled($this->personalMerchandisingAnalytics->getStoreManager()->getStore())) {
             return $this->helper->getTweakwiseId($storeId, (int)$itemId);
         }
 

--- a/Model/Client/Request/Recommendations/ProductRequest.php
+++ b/Model/Client/Request/Recommendations/ProductRequest.php
@@ -67,6 +67,19 @@ class ProductRequest extends FeaturedRequest
         }
 
         $productTweakwiseId = $this->helper->getTweakwiseId($this->product->getStoreId(), $this->product->getId());
+
+        if ($this->config->isGroupedProductsEnabled($this->product->getStore())) {
+            $groupcode = $this->product->getData('groupcode');
+
+            if (empty($groupcode)) {
+                $groupcode = $this->product->getId();
+            }
+
+            $groupcode = $this->helper->getTweakwiseId($this->product->getStoreId(), $groupcode);
+
+            $productTweakwiseId = $this->helper->getTweakwiseId($this->product->getStoreId(), $this->product->getId(), $groupcode);
+        }
+
         // @phpstan-ignore-next-line
         if (is_int($this->templateId)) {
             return parent::getPathSuffix() . '/' . $productTweakwiseId;
@@ -86,6 +99,7 @@ class ProductRequest extends FeaturedRequest
         $children = $product->getTypeInstance()->getUsedProducts($product);
         foreach ($children as $child) {
             if ($child->isSaleable() && $child->getTypeId() === Type::TYPE_SIMPLE) {
+                $child->setData('groupcode', $product->getId());
                 return $child;
             }
         }

--- a/Model/Client/Request/Recommendations/ProductRequest.php
+++ b/Model/Client/Request/Recommendations/ProductRequest.php
@@ -69,15 +69,15 @@ class ProductRequest extends FeaturedRequest
         $productTweakwiseId = $this->helper->getTweakwiseId($this->product->getStoreId(), $this->product->getId());
 
         if ($this->config->isGroupedProductsEnabled($this->product->getStore())) {
-            $groupcode = $this->product->getData('groupcode');
+            $groupCode = $this->product->getData('groupcode');
 
-            if (empty($groupcode)) {
-                $groupcode = $this->product->getId();
+            if (empty($groupCode)) {
+                $groupCode = $this->product->getId();
             }
 
-            $groupcode = $this->helper->getTweakwiseId($this->product->getStoreId(), $groupcode);
+            $groupCode = $this->helper->getTweakwiseId($this->product->getStoreId(), $groupCode);
 
-            $productTweakwiseId = $this->helper->getTweakwiseId($this->product->getStoreId(), $this->product->getId(), $groupcode);
+            $productTweakwiseId = $this->helper->getTweakwiseId($this->product->getStoreId(), $this->product->getId(), $groupCode);
         }
 
         // @phpstan-ignore-next-line

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -107,6 +107,11 @@ class ProductNavigationResponse extends Response
                 $data[ItemType::TWEAKWISE_ID] = $tweakwiseId;
             }
 
+            $groupCode = $item->getGroupCodeFromAttributes();
+            if (!empty($groupCode)) {
+                $data[ItemType::GROUPCODE] = $groupCode;
+            }
+
             $data[ItemType::COLSPAN] = $item->getColspan();
             $data[ItemType::ROWSPAN] = $item->getRowspan();
 

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -107,11 +107,6 @@ class ProductNavigationResponse extends Response
                 $data[ItemType::TWEAKWISE_ID] = $tweakwiseId;
             }
 
-            $groupCode = $item->getGroupCodeFromAttributes();
-            if (!empty($groupCode)) {
-                $data[ItemType::GROUPCODE] = $groupCode;
-            }
-
             $data[ItemType::COLSPAN] = $item->getColspan();
             $data[ItemType::ROWSPAN] = $item->getRowspan();
 

--- a/Model/Client/Type/ItemType.php
+++ b/Model/Client/Type/ItemType.php
@@ -145,13 +145,9 @@ class ItemType extends Type
      */
     public function getGroupCodeFromAttributes(): string
     {
-        $attributes = $this->getDataValue(self::ATTRIBUTES);
+        $attributes = $this->normalizeArray($this->getDataValue(self::ATTRIBUTES), 'attribute');
 
         foreach ($attributes as $attribute) {
-            if (!is_array($attribute)) {
-                $attribute = $attributes['attribute'];
-            }
-
             if (
                 isset($attribute['name']) &&
                 $attribute['name'] === 'groupcode' &&

--- a/Observer/Event/SendAddToCartEvent.php
+++ b/Observer/Event/SendAddToCartEvent.php
@@ -76,21 +76,26 @@ class SendAddToCartEvent implements ObserverInterface
         $totalAmount = $quoteItem->getQtyToAdd() * $product->getPriceModel()->getFinalPrice($quoteItem->getQtyToAdd(), $product);
 
         $productId = $quoteItem->getProductId();
+        $groupCode = null;
 
         if ($this->config->isGroupedProductsEnabled()) {
+            $groupCode = (int)$this->helper->getTweakwiseId((int)$this->storeManager->getStore()->getId(), (int)$quoteItem->getProductId());
             if (!empty($quoteItem->getQtyOptions())) {
                 $productId = array_key_first($quoteItem->getQtyOptions());
             }
         }
 
+        $productId = $this->helper->getTweakwiseId(
+            (int)$this->storeManager->getStore()->getId(),
+            (int)$productId,
+            $groupCode,
+        );
+
         $tweakwiseRequest->setProfileKey($this->config->getProfileKey());
         $tweakwiseRequest->setParameter('SessionKey', $this->eventService->getSessionKey());
         $tweakwiseRequest->setParameter(
             'ProductKey',
-            $this->helper->getTweakwiseId(
-                (int)$this->storeManager->getStore()->getId(),
-                (int)$productId
-            )
+            $productId
         );
         $tweakwiseRequest->setParameter('Quantity', (string)$quoteItem->getQtyToAdd());
         $tweakwiseRequest->setParameter('TotalAmount', (string)$totalAmount);

--- a/Observer/Event/SendAddToWishlistEvent.php
+++ b/Observer/Event/SendAddToWishlistEvent.php
@@ -71,11 +71,14 @@ class SendAddToWishlistEvent implements ObserverInterface
         }
 
         $productId = (int)$product->getId();
+        $groupCode = null;
+        $storeId = (int)$this->storeManager->getStore()->getId();
 
         if ($this->config->isGroupedProductsEnabled()) {
             /** @var ProductExtension $extensionAttributes */
             $extensionAttributes = $product->getExtensionAttributes();
             $children = $extensionAttributes->getConfigurableProductLinks();
+            $groupCode = (int)$this->helper->getTweakwiseId($storeId,$productId);
             if (!empty($children)) {
                 $productId = (int)array_first($children);
             }
@@ -87,8 +90,9 @@ class SendAddToWishlistEvent implements ObserverInterface
         $tweakwiseRequest->setParameter(
             'ProductKey',
             $this->helper->getTweakwiseId(
-                (int)$this->storeManager->getStore()->getId(),
-                $productId
+                $storeId,
+                $productId,
+                $groupCode,
             )
         );
         $tweakwiseRequest->setPath('addtowishlist');

--- a/Observer/Event/SendAddToWishlistEvent.php
+++ b/Observer/Event/SendAddToWishlistEvent.php
@@ -78,7 +78,7 @@ class SendAddToWishlistEvent implements ObserverInterface
             /** @var ProductExtension $extensionAttributes */
             $extensionAttributes = $product->getExtensionAttributes();
             $children = $extensionAttributes->getConfigurableProductLinks();
-            $groupCode = (int)$this->helper->getTweakwiseId($storeId,$productId);
+            $groupCode = (int)$this->helper->getTweakwiseId($storeId, $productId);
             if (!empty($children)) {
                 $productId = (int)array_first($children);
             }

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Tweakwise\Magento2Tweakwise\Observer;
 
-use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Model\Order\Item;
+use Psr\Log\LoggerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Client;
 use Tweakwise\Magento2Tweakwise\Model\Client\RequestFactory;
 use Tweakwise\Magento2Tweakwise\Model\PersonalMerchandisingConfig;
 use Tweakwise\Magento2Tweakwise\Service\Event\EventService;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Magento\Store\Model\StoreManagerInterface;
+use Throwable;
 
 class TweakwiseCheckout implements ObserverInterface
 {
@@ -24,6 +25,7 @@ class TweakwiseCheckout implements ObserverInterface
      * @param StoreManagerInterface $storeManager
      * @param PersonalMerchandisingConfig $config
      * @param EventService $eventService
+     * @param LoggerInterface $logger
      */
     public function __construct(
         private readonly RequestFactory $requestFactory,
@@ -32,6 +34,7 @@ class TweakwiseCheckout implements ObserverInterface
         private readonly StoreManagerInterface $storeManager,
         private readonly PersonalMerchandisingConfig $config,
         private readonly EventService $eventService,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -54,7 +57,7 @@ class TweakwiseCheckout implements ObserverInterface
             $items = $order->getAllItems();
 
             $this->sendCheckout($items, $totalExclTax);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->logger->error('Tweakwise checkout event could not be sent', ['message' => $e->getMessage()]);
             return;
         }
@@ -100,14 +103,17 @@ class TweakwiseCheckout implements ObserverInterface
         }
 
          foreach ($items as $item) {
-             $groupCode = null;
+             $originalItem = $item->getProductId();
              if ($this->config->isGroupedProductsEnabled()) {
-                 $groupCode = $item->getData('groupCode');
-                 if (!empty($groupCode)) {
-                     $groupCode = (int)$this->helper->getTweakwiseId($storeId, (int)$groupCode);
+                 $originalItem = $item->getData('groupCode');
+                 if (!empty($originalItem)) {
+                     $groupcode =(int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
                  }
+
+                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupcode ?? null);
+             } else {
+                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
              }
-             $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId(), $groupCode);
          }
 
          $tweakwiseRequest->setParameterArray('ProductKeys', $productTwId);

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -107,7 +107,7 @@ class TweakwiseCheckout implements ObserverInterface
             if ($this->config->isGroupedProductsEnabled()) {
                 $originalItem = $item->getData('groupCode');
                 if (!empty($originalItem)) {
-                    $groupcode =(int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+                    $groupcode = (int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
                 }
 
                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupcode ?? null);

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -102,21 +102,21 @@ class TweakwiseCheckout implements ObserverInterface
             ));
         }
 
-         foreach ($items as $item) {
-             $originalItem = $item->getProductId();
-             if ($this->config->isGroupedProductsEnabled()) {
-                 $originalItem = $item->getData('groupCode');
-                 if (!empty($originalItem)) {
-                     $groupcode =(int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
-                 }
+        foreach ($items as $item) {
+            $originalItem = $item->getProductId();
+            if ($this->config->isGroupedProductsEnabled()) {
+                $originalItem = $item->getData('groupCode');
+                if (!empty($originalItem)) {
+                    $groupcode =(int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+                }
 
-                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupcode ?? null);
-             } else {
-                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
-             }
-         }
+                $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupcode ?? null);
+            } else {
+                $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+            }
+        }
 
-         $tweakwiseRequest->setParameterArray('ProductKeys', $productTwId);
-         $this->client->request($tweakwiseRequest);
+        $tweakwiseRequest->setParameterArray('ProductKeys', $productTwId);
+        $this->client->request($tweakwiseRequest);
     }
 }

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tweakwise\Magento2Tweakwise\Observer;
 
+use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Model\Order\Item;
@@ -42,16 +43,21 @@ class TweakwiseCheckout implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        if (!$this->config->isAnalyticsEnabled()) {
+        try {
+            if (!$this->config->isAnalyticsEnabled()) {
+                return;
+            }
+
+            $order = $observer->getEvent()->getOrder();
+            $totalExclTax = (float)$order->getBaseSubtotal();
+            // Get the order items
+            $items = $order->getAllItems();
+
+            $this->sendCheckout($items, $totalExclTax);
+        } catch (Exception $e) {
+            $this->logger->error('Tweakwise checkout event could not be sent', ['message' => $e->getMessage()]);
             return;
         }
-
-        $order = $observer->getEvent()->getOrder();
-        $totalExclTax = (float)$order->getBaseSubtotal();
-        // Get the order items
-        $items = $order->getAllItems();
-
-        $this->sendCheckout($items, $totalExclTax);
     }
 
     /**
@@ -63,6 +69,10 @@ class TweakwiseCheckout implements ObserverInterface
      */
     private function sendCheckout($items, float $totalExclTax): void
     {
+        if (empty($items) && !is_array($items)) {
+            return;
+        }
+
         $storeId = (int)$this->storeManager->getStore()->getId();
         $profileKey = $this->config->getProfileKey();
         $tweakwiseRequest = $this->requestFactory->create();
@@ -73,30 +83,34 @@ class TweakwiseCheckout implements ObserverInterface
         $tweakwiseRequest->setPath('purchase');
 
         if ($this->config->isGroupedProductsEnabled()) {
-            $items = array_filter(
-                $items,
-                fn($item) => $item->getParentItem() !== null
-            );
+            $filteredItems = [];
+
+            foreach ($items as $originalItem) {
+                $returnedItem = $originalItem->getParentItem() ?? $originalItem;
+                $returnedItem->setData('groupCode', $originalItem->getProductId());
+                $filteredItems[(int)$returnedItem->getId()] = $returnedItem;
+            }
+
+            $items = array_values($filteredItems);
         } else {
-            $items = array_filter(
+            $items = array_values(array_filter(
                 $items,
-                fn($item) => $item->getParentItem() === null
-            );
+                fn (Item $item): bool => $item->getParentItem() === null
+            ));
         }
 
-        foreach ($items as $item) {
-            $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
-        }
+         foreach ($items as $item) {
+             $groupCode = null;
+             if ($this->config->isGroupedProductsEnabled()) {
+                 $groupCode = $item->getData('groupCode');
+                 if (!empty($groupCode)) {
+                     $groupCode = (int)$this->helper->getTweakwiseId($storeId, (int)$groupCode);
+                 }
+             }
+             $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId(), $groupCode);
+         }
 
-        // @phpstan-ignore-next-line
-        $tweakwiseRequest->setParameterArray('ProductKeys', $productTwId);
-
-        // @phpcs:disable
-        try {
-            $this->client->request($tweakwiseRequest);
-        } catch (\Exception $e) {
-            // Do nothing so that the checkout process can continue
-        }
-        // @phpcs:enable
+         $tweakwiseRequest->setParameterArray('ProductKeys', $productTwId);
+         $this->client->request($tweakwiseRequest);
     }
 }

--- a/Observer/TweakwiseCheckout.php
+++ b/Observer/TweakwiseCheckout.php
@@ -8,13 +8,13 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Model\Order\Item;
 use Psr\Log\LoggerInterface;
+use Throwable;
 use Tweakwise\Magento2Tweakwise\Model\Client;
 use Tweakwise\Magento2Tweakwise\Model\Client\RequestFactory;
 use Tweakwise\Magento2Tweakwise\Model\PersonalMerchandisingConfig;
 use Tweakwise\Magento2Tweakwise\Service\Event\EventService;
 use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 use Magento\Store\Model\StoreManagerInterface;
-use Throwable;
 
 class TweakwiseCheckout implements ObserverInterface
 {
@@ -102,15 +102,16 @@ class TweakwiseCheckout implements ObserverInterface
             ));
         }
 
+        $productTwId = [];
+
         foreach ($items as $item) {
-            $originalItem = $item->getProductId();
             if ($this->config->isGroupedProductsEnabled()) {
                 $originalItem = $item->getData('groupCode');
                 if (!empty($originalItem)) {
-                    $groupcode = (int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
+                    $groupCode = (int)$this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
                 }
 
-                $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupcode ?? null);
+                $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$originalItem, $groupCode ?? null);
             } else {
                 $productTwId[] = $this->helper->getTweakwiseId($storeId, (int)$item->getProductId());
             }

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -74,10 +74,11 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
     private function getGroupedProductId(int $productId, int $storeId): string
     {
         try {
-            /** @var Product $product */
+            $groupcode = $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+                /** @var Product $product */
             $product = $this->productRepository->getById($productId);
             if ($product->getTypeId() === Type::TYPE_SIMPLE) {
-                return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+                return $this->helper->getTweakwiseId((int)$storeId, (int)$productId, (int)$groupcode);
             }
 
             $associatedProducts = $this->getAssociatedProducts($product);
@@ -89,7 +90,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
             // Do nothing
         }
 
-        return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+        return $this->helper->getTweakwiseId((int)$storeId, (int)$productId, (int)$groupcode);
     }
 
     /**

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -65,9 +65,9 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
 
     /**
      * @param int $productId
-     * @return int|tring
+     * @return int|string
      */
-    private function getGroupedProductId(int $productId): int|string
+    public function getGroupedProductId(int $productId): int|string
     {
         try {
             /** @var Product $product */

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -51,7 +51,6 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
     public function getProductKey(): string
     {
         $productId = $this->request->getParam('id');
-        $storeId = $this->storeManager->getStore()->getId();
 
         if (!$productId) {
             return '0';
@@ -61,15 +60,14 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
             return $productId;
         }
 
-        return (string)$this->getGroupedProductId((int)$productId, (int)$storeId);
+        return (string)$this->getGroupedProductId((int)$productId);
     }
 
     /**
      * @param int $productId
-     * @param int $storeId
      * @return int|tring
      */
-    private function getGroupedProductId(int $productId, int $storeId): int|string
+    private function getGroupedProductId(int $productId): int|string
     {
         try {
             /** @var Product $product */

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -58,39 +58,42 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
         }
 
         if (!$this->tweakwiseConfig->isGroupedProductsEnabled()) {
-            return $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
+            return $productId;
         }
 
-        return $this->getGroupedProductId((int)$productId, (int)$storeId);
+        return (string)$this->getGroupedProductId((int)$productId, (int)$storeId);
     }
 
     /**
-     * Get the grouped product ID.
-     *
      * @param int $productId
      * @param int $storeId
-     * @return string
+     * @return int|tring
      */
-    private function getGroupedProductId(int $productId, int $storeId): string
+    private function getGroupedProductId(int $productId, int $storeId): int|string
     {
         try {
-            $groupcode = $this->helper->getTweakwiseId((int)$storeId, (int)$productId);
-                /** @var Product $product */
+            /** @var Product $product */
             $product = $this->productRepository->getById($productId);
-            if ($product->getTypeId() === Type::TYPE_SIMPLE) {
-                return $this->helper->getTweakwiseId((int)$storeId, (int)$productId, (int)$groupcode);
-            }
-
-            $associatedProducts = $this->getAssociatedProducts($product);
-            if (!empty($associatedProducts)) {
-                $firstAssociatedProduct = reset($associatedProducts);
-                $productId = $firstAssociatedProduct->getId();
-            }
         } catch (NoSuchEntityException $e) {
-            // Do nothing
+            return $productId;
         }
 
-        return $this->helper->getTweakwiseId((int)$storeId, (int)$productId, (int)$groupcode);
+        if ($product->getTypeId() === Type::TYPE_SIMPLE) {
+            return $productId;
+        }
+
+        $associatedProducts = $this->getAssociatedProducts($product);
+        if (empty($associatedProducts)) {
+            return $productId;
+        }
+
+        $firstAssociatedProduct = reset($associatedProducts);
+        $simpleId = $firstAssociatedProduct->getId();
+        if ($simpleId === 0 || $simpleId === $productId) {
+            return $productId;
+        }
+
+        return $simpleId . Helper::GROUP_CODE_DELIMITER . $productId;
     }
 
     /**

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -36,7 +36,7 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
     public function __construct(
         private readonly Config $tweakwiseConfig,
         private readonly Helper $helper,
-        private readonly StoreManagerInterface $storeManager,
+        public readonly StoreManagerInterface $storeManager,
         private readonly RequestInterface $request,
         private readonly Json $jsonSerializer,
         private readonly ProductRepositoryInterface $productRepository,

--- a/ViewModel/PersonalMerchandisingAnalytics.php
+++ b/ViewModel/PersonalMerchandisingAnalytics.php
@@ -36,11 +36,21 @@ class PersonalMerchandisingAnalytics implements ArgumentInterface
     public function __construct(
         private readonly Config $tweakwiseConfig,
         private readonly Helper $helper,
-        public readonly StoreManagerInterface $storeManager,
+        private readonly StoreManagerInterface $storeManager,
         private readonly RequestInterface $request,
         private readonly Json $jsonSerializer,
         private readonly ProductRepositoryInterface $productRepository,
     ) {
+    }
+
+    /**
+     * Get the store manager.
+     *
+     * @return StoreManagerInterface
+     */
+    public function getStoreManager(): StoreManagerInterface
+    {
+        return $this->storeManager;
     }
 
     /**

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -145,7 +145,8 @@ class ProductListItem implements ArgumentInterface
             ->setData('show_description', $showDescription)
             ->setData('pos', $parentBlock->getPositioned())
             ->setData('output_helper', $parentBlock->getData('outputHelper'))
-            ->setData('template_type', $templateType);
+            ->setData('template_type', $templateType)
+            ->setData('tw_id', $product->getData('tw_id') ? $product->getId() . '|'. $product->getData('tw_id') : $product->getId());
 
         return $itemRendererBlock->toHtml();
     }

--- a/ViewModel/ProductListItem.php
+++ b/ViewModel/ProductListItem.php
@@ -14,6 +14,7 @@ use Magento\Framework\View\LayoutInterface;
 use Tweakwise\Magento2Tweakwise\Helper\Cache;
 use Tweakwise\Magento2Tweakwise\Model\Visual;
 use Magento\Store\Model\StoreManagerInterface;
+use Tweakwise\Magento2TweakwiseExport\Model\Helper;
 
 class ProductListItem implements ArgumentInterface
 {
@@ -146,7 +147,7 @@ class ProductListItem implements ArgumentInterface
             ->setData('pos', $parentBlock->getPositioned())
             ->setData('output_helper', $parentBlock->getData('outputHelper'))
             ->setData('template_type', $templateType)
-            ->setData('tw_id', $product->getData('tw_id') ? $product->getId() . '|'. $product->getData('tw_id') : $product->getId());
+            ->setData('tw_id', $product->getData('tw_id') ? $product->getData('tw_id')  . Helper::GROUP_CODE_DELIMITER . $product->getId() : $product->getId());
 
         return $itemRendererBlock->toHtml();
     }

--- a/view/frontend/templates/product/list/item.phtml
+++ b/view/frontend/templates/product/list/item.phtml
@@ -24,7 +24,7 @@ $pos = $block->getData('pos');
 $_helper = $block->getData('output_helper');
 $templateType = $block->getData('template_type');
 $showDescription = $block->getData('show_description');
-$productId = $_product->getData('tw_id') ?: $_product->getId();
+$productId = $block->getData('tw_id');
 ?>
 <li class="item product product-item">
     <div class="product-item-info"


### PR DESCRIPTION
## Description
This PR fixes a compatibility issue introduced by [PR #139](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/pull/139). 

In PR #139, the Grouped Export ID format was changed to `{simple_id}-{parent_id}`. This change caused Tweakwise tracking events to fail because the events were still sending the original product IDs, which no longer matched the IDs indexed in Tweakwise. This PR updates the event logic to ensure the correct ID format is transmitted.

> [!IMPORTANT]
> **Upgrade Note:** The composer version of the export module needs to be updated upon release.

> [!WARNING]
> **Template Overrides:** If you have overwritten the template file `view/frontend/templates/product/list/item.phtml` in your theme or project, you **must** manually update it to ensure the product ID in the HTML matches the new format.

---

## How to Test

### Prerequisites
* Ensure [PR #139](https://github.com/EmicoEcommerce/Magento2TweakwiseExport/pull/139) is installed and active.

### Scenario 1: Grouped Export
1. Run a **Grouped Export** and ensure products are indexed in Tweakwise with the new ID format (`simple-parent`).
2. Navigate to the storefront and verify the following events send IDs that match the Tweakwise index:
    * Item Click
    * Product Page Impression
    * Add to Cart
    * Add to Wishlist
    * Purchase Event

### Scenario 2: Non-Grouped Export (Regression)
1. Run a standard **Non-Grouped Export**.
2. Verify the same events still send the standard product IDs correctly without the parent suffix.