### PR TITLE
Fix: visual properties

### DIFF
--- a/Api/Data/VisualInterface.php
+++ b/Api/Data/VisualInterface.php
@@ -52,12 +52,4 @@ interface VisualInterface
      * @return self
      */
     public function setRowspan(int $rowspan): self;
-
-    /**
-     * Returns an inline CSS style string for grid-column/grid-row spanning,
-     * e.g. "grid-column: span 2;grid-row: span 2;" — empty string when not applicable.
-     *
-     * @return string
-     */
-    public function getGridStyle(): string;
 }

--- a/Api/Data/VisualInterface.php
+++ b/Api/Data/VisualInterface.php
@@ -52,4 +52,12 @@ interface VisualInterface
      * @return self
      */
     public function setRowspan(int $rowspan): self;
+
+    /**
+     * Returns an inline CSS style string for grid-column/grid-row spanning,
+     * e.g. "grid-column: span 2;grid-row: span 2;" — empty string when not applicable.
+     *
+     * @return string
+     */
+    public function getGridStyle(): string;
 }

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -338,6 +338,10 @@ class Collection extends AbstractCollection
     }
 
     /**
+     * Remove the simple variant entry from the collection when its configurable parent is also present
+     * (grouped products mode). Uses the product entity_id rather than the array key, because addVisuals()
+     * calls array_splice() which reindexes the integer keys of $this->_items.
+     *
      * @return void
      */
     protected function removeDuplicatedProducts(): void
@@ -346,17 +350,33 @@ class Collection extends AbstractCollection
             return;
         }
 
+        // Build a map of entity_id => array key so we can locate items regardless of the
+        // (possibly reindexed) integer keys after array_splice in addVisuals().
+        $entityIdToKey = [];
+        foreach ($this->_items as $key => $item) {
+            if (!$item instanceof ProductInterface) {
+                continue;
+            }
+            $entityIdToKey[(int)$item->getId()] = $key;
+        }
+
         foreach ($this->_items as $key => $item) {
             if (!$item instanceof ProductInterface) {
                 continue;
             }
 
-            $twId = (int)$item->getData('tw_id') ?? '0';
-            if (!isset($this->_items[$twId]) || $key === $twId) {
+            $twId = (int)$item->getData('tw_id');
+            if ($twId === 0 || $twId === (int)$item->getId()) {
                 continue;
             }
 
-            unset($this->_items[$twId]);
+            if (!isset($entityIdToKey[$twId])) {
+                continue;
+            }
+
+            $duplicateKey = $entityIdToKey[$twId];
+            unset($this->_items[$duplicateKey]);
+            unset($entityIdToKey[$twId]);
         }
     }
 }

--- a/Model/Catalog/Product/Collection.php
+++ b/Model/Catalog/Product/Collection.php
@@ -352,31 +352,29 @@ class Collection extends AbstractCollection
 
         // Build a map of entity_id => array key so we can locate items regardless of the
         // (possibly reindexed) integer keys after array_splice in addVisuals().
-        $entityIdToKey = [];
-        foreach ($this->_items as $key => $item) {
+        $entityIdToKey = array_reduce(
+            array_keys($this->_items),
+            function (array $carry, $key): array {
+                $item = $this->_items[$key];
+                if ($item instanceof ProductInterface) {
+                    $carry[(int) $item->getId()] = $key;
+                }
+                return $carry;
+            },
+            []
+        );
+
+        foreach ($this->_items as $item) {
             if (!$item instanceof ProductInterface) {
                 continue;
             }
-            $entityIdToKey[(int)$item->getId()] = $key;
-        }
 
-        foreach ($this->_items as $key => $item) {
-            if (!$item instanceof ProductInterface) {
+            $twId = (int) $item->getData('tw_id');
+            if ($twId === 0 || $twId === (int) $item->getId() || !isset($entityIdToKey[$twId])) {
                 continue;
             }
 
-            $twId = (int)$item->getData('tw_id');
-            if ($twId === 0 || $twId === (int)$item->getId()) {
-                continue;
-            }
-
-            if (!isset($entityIdToKey[$twId])) {
-                continue;
-            }
-
-            $duplicateKey = $entityIdToKey[$twId];
-            unset($this->_items[$duplicateKey]);
-            unset($entityIdToKey[$twId]);
+            unset($this->_items[$entityIdToKey[$twId]], $entityIdToKey[$twId]);
         }
     }
 }

--- a/Model/Client/Response.php
+++ b/Model/Client/Response.php
@@ -140,7 +140,13 @@ class Response extends Type
      */
     protected function getConfigurable(array $group): array
     {
-        return ['itemno' => $group['code']];
+        $configurable = ['itemno' => $group['code']];
+
+        if (isset($group[ItemType::VISUAL_PROPERTIES])) {
+            $configurable[ItemType::VISUAL_PROPERTIES] = $group[ItemType::VISUAL_PROPERTIES];
+        }
+
+        return $configurable;
     }
 
     /**

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -95,7 +95,10 @@ class ProductNavigationResponse extends Response
         $productData = [];
         // @phpstan-ignore-next-line
         foreach ($this->getItems() as $item) {
-            $data = [];
+            $storeId = $this->helper->getStoreId($item->getId());
+
+            $data = $productData[$storeId] ?? [];
+
             if ($item->getImage()) {
                 // Remove domain and media path when full url is used
                 $imageUrl = preg_replace('#^.*?/catalog/product/#', '', $item->getImage());
@@ -107,10 +110,15 @@ class ProductNavigationResponse extends Response
                 $data[ItemType::TWEAKWISE_ID] = $tweakwiseId;
             }
 
-            $data[ItemType::COLSPAN] = $item->getColspan();
-            $data[ItemType::ROWSPAN] = $item->getRowspan();
+            // When multiple Tweakwise group codes resolve to the same Magento store ID (via
+            // getStoreId), keep the maximum colspan/rowspan so that a merchandised span is
+            // never silently overwritten by a subsequent item with a lower value.
+            $colspan = (int) $item->getColspan();
+            $rowspan = (int) $item->getRowspan();
+            $data[ItemType::COLSPAN] = max($colspan, (int) ($data[ItemType::COLSPAN] ?? 0)) ?: null;
+            $data[ItemType::ROWSPAN] = max($rowspan, (int) ($data[ItemType::ROWSPAN] ?? 0)) ?: null;
 
-            $productData[$this->helper->getStoreId($item->getId())] = $data;
+            $productData[$storeId] = $data;
         }
 
         return $productData;

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -95,9 +95,9 @@ class ProductNavigationResponse extends Response
         $productData = [];
         // @phpstan-ignore-next-line
         foreach ($this->getItems() as $item) {
-            $storeId = $this->helper->getStoreId($item->getId());
+            $itemId = $this->helper->getStoreId($item->getId());
 
-            $data = $productData[$storeId] ?? [];
+            $data = $productData[$itemId] ?? [];
 
             if ($item->getImage()) {
                 // Remove domain and media path when full url is used
@@ -120,7 +120,7 @@ class ProductNavigationResponse extends Response
             $rowspanMax = max($rowspan, (int) ($data[ItemType::ROWSPAN] ?? 0));
             $data[ItemType::ROWSPAN] = $rowspanMax !== 0 ? $rowspanMax : null;
 
-            $productData[$storeId] = $data;
+            $productData[$itemId] = $data;
         }
 
         return $productData;

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -115,8 +115,10 @@ class ProductNavigationResponse extends Response
             // never silently overwritten by a subsequent item with a lower value.
             $colspan = (int) $item->getColspan();
             $rowspan = (int) $item->getRowspan();
-            $data[ItemType::COLSPAN] = max($colspan, (int) ($data[ItemType::COLSPAN] ?? 0)) ?: null;
-            $data[ItemType::ROWSPAN] = max($rowspan, (int) ($data[ItemType::ROWSPAN] ?? 0)) ?: null;
+            $colspanMax = max($colspan, (int) ($data[ItemType::COLSPAN] ?? 0));
+            $data[ItemType::COLSPAN] = $colspanMax !== 0 ? $colspanMax : null;
+            $rowspanMax = max($rowspan, (int) ($data[ItemType::ROWSPAN] ?? 0));
+            $data[ItemType::ROWSPAN] = $rowspanMax !== 0 ? $rowspanMax : null;
 
             $productData[$storeId] = $data;
         }

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -113,12 +113,14 @@ class ProductNavigationResponse extends Response
             // When multiple Tweakwise group codes resolve to the same Magento store ID (via
             // getStoreId), keep the maximum colspan/rowspan so that a merchandised span is
             // never silently overwritten by a subsequent item with a lower value.
-            $colspan = (int) $item->getColspan();
-            $rowspan = (int) $item->getRowspan();
-            $colspanMax = max($colspan, (int) ($data[ItemType::COLSPAN] ?? 0));
-            $data[ItemType::COLSPAN] = $colspanMax !== 0 ? $colspanMax : null;
-            $rowspanMax = max($rowspan, (int) ($data[ItemType::ROWSPAN] ?? 0));
-            $data[ItemType::ROWSPAN] = $rowspanMax !== 0 ? $rowspanMax : null;
+            $data[ItemType::COLSPAN] = max(
+                (int) $item->getColspan(),
+                (int) ($data[ItemType::COLSPAN] ?? 0)
+            ) ?: null;
+            $data[ItemType::ROWSPAN] = max(
+                (int) $item->getRowspan(),
+                (int) ($data[ItemType::ROWSPAN] ?? 0)
+            ) ?: null;
 
             $productData[$itemId] = $data;
         }

--- a/Model/Client/Response/ProductNavigationResponse.php
+++ b/Model/Client/Response/ProductNavigationResponse.php
@@ -113,14 +113,10 @@ class ProductNavigationResponse extends Response
             // When multiple Tweakwise group codes resolve to the same Magento store ID (via
             // getStoreId), keep the maximum colspan/rowspan so that a merchandised span is
             // never silently overwritten by a subsequent item with a lower value.
-            $data[ItemType::COLSPAN] = max(
-                (int) $item->getColspan(),
-                (int) ($data[ItemType::COLSPAN] ?? 0)
-            ) ?: null;
-            $data[ItemType::ROWSPAN] = max(
-                (int) $item->getRowspan(),
-                (int) ($data[ItemType::ROWSPAN] ?? 0)
-            ) ?: null;
+            $colspan = max((int) $item->getColspan(), (int) ($data[ItemType::COLSPAN] ?? 0));
+            $data[ItemType::COLSPAN] = $colspan !== 0 ? $colspan : null;
+            $rowspan = max((int) $item->getRowspan(), (int) ($data[ItemType::ROWSPAN] ?? 0));
+            $data[ItemType::ROWSPAN] = $rowspan !== 0 ? $rowspan : null;
 
             $productData[$itemId] = $data;
         }


### PR DESCRIPTION
## Summary
- Propagate `visual_properties` from grouped product responses to configurable items so visual grid spans render correctly
- Fix `removeDuplicatedProducts()` to correctly resolve duplicates by `entity_id` after `array_splice()` reindexes `$this->_items` in `addVisuals()`

## Changes
- **`Model/Client/Response.php`**: `getConfigurable()` now forwards `VISUAL_PROPERTIES` from the group when present, instead of only returning `itemno`.
- **`Model/Catalog/Product/Collection.php`**: Rewrote `removeDuplicatedProducts()` to build an `entity_id => key` map before unsetting duplicates. Previous logic incorrectly used `tw_id` as an array key, which was unreliable because `addVisuals()` reindexes integer keys via `array_splice()`. Also fixed an invalid `?? '0'` on a casted int and added an early-return guard when `tw_id` equals the item id.

## Why
When grouped products are enabled, simple variants whose configurable parent is also in the result set were not being deduplicated correctly, and visual properties (colspan/rowspan) defined on the configurable group were not reaching the rendered configurable item. 

## Testing
- Verify category pages with grouped/configurable products render the correct amount of products when visuals are shown
- Verify that the frontend have the rowspan, colspan information for grouped products