### PR TITLE
fix: category link

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/DefaultRenderer.php
@@ -162,7 +162,7 @@ class DefaultRenderer extends Template
         }
 
         foreach ($items as $item) {
-            if ($item->getAttribute()->getValue('attributeid') === $tweakwiseCategoryId) {
+            if ((int)$item->getAttribute()->getValue('attributeid') === (int)$tweakwiseCategoryId) {
                 if (!empty($item->getChildren())) {
                     return $item->getChildren();
                 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the **Tweakwise** integration where the category filter displayed incorrect levels when configured as a **Link**. 

On subcategory pages (e.g., `/women/tops`), the filter was defaulting to parent-level categories instead of showing the relevant subcategories.

## How to Test
1. Set the Category filter type to **Link** in the Tweakwise configuration.
2. Navigate to a subcategory page with nested children (e.g., *Apparel > Women > Tops*).
3. **Actual Result (Before):** The filter shows *Apparel, Men, Gear*.
4. **Expected Result (After):** The filter shows *Jackets, Hoodies & Sweatshirts, Tees, Bras & Tanks*.