### PR TITLE
fix: page parameter always added

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/AnchorRendererTrait.php
+++ b/Block/LayeredNavigation/RenderLayered/AnchorRendererTrait.php
@@ -43,7 +43,12 @@ trait AnchorRendererTrait
      */
     protected function getAnchorTagAttributes(Item $item): array
     {
-        $itemUrl = preg_replace('/&amp;p=\d+/', '', $this->getItemUrl($item));
+        $itemUrl = $this->getItemUrl($item);
+        // Remove p= from mid-query (e.g. ?color=red&amp;p=4 or ?color=red&p=4&amp;size=M)
+        $itemUrl = preg_replace('/(&amp;|&)p=\d+/', '', (string) $itemUrl);
+        // Remove p= when it is the first query parameter (e.g. ?p=4 or ?p=4&amp;color=red)
+        $itemUrl = preg_replace('/\?p=\d+(&amp;|&)?/', '?', (string) $itemUrl);
+        $itemUrl = rtrim($itemUrl, '?');
         if ($this->filterHelper->shouldFilterBeIndexable($item)) {
             return ['href' => $itemUrl];
         }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -246,13 +246,16 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
             $categoryUrl = $category->getUrl();
             $categoryUrlPath = parse_url($categoryUrl, PHP_URL_PATH);
 
+            $categoryFilters = $this->getAttributeFilters($request);
+            unset($categoryFilters[self::PARAM_PAGE]);
+
             $url = $this->url->getDirectUrl(
                 sprintf(
                     '%s/',
                     trim($categoryUrlPath, '/'), // @phpstan-ignore-line
                 ),
                 [
-                    '_query' => $this->getAttributeFilters($request)
+                    '_query' => $categoryFilters
                 ]
             );
 


### PR DESCRIPTION
## Summary

- Fixes #341 
- Fix pagination parameter (`p=`) being carried over to subcategory URLs when clicking a category in the filter panel while on a paginated page (e.g. `?p=4`).
- In `QueryParameterStrategy::getCategoryFilterSelectUrl()`, explicitly unset `PARAM_PAGE` from the filters array before building the category URL. This is surgical: only the category filter link is affected — `buildFilterUrl()` (used to build the AJAX response URL pushed to the browser address bar) is left intact, so `?p=4` is still correctly reflected after paginating.
- Fix an incomplete regex in `AnchorRendererTrait::getAnchorTagAttributes()` that stripped `p=` from filter option hrefs only when it appeared as a secondary query parameter (`&amp;p=4`). Replaced with two sequential replacements that cover all positions: sole parameter (`?p=4`), first parameter followed by others (`?p=4&amp;color=red`), and mid/trailing parameter (`?color=red&amp;p=4`).

## How to test

**Scenario 1 — Switching subcategory via category filter does not carry the page parameter**

1. Using the QueryParameter URL strategy, open a category with subcategories listed in the filter panel.
2. Navigate to a page beyond page 1 (e.g. `?p=10`).
3. Click a subcategory link in the filter panel.
4. Verify the resulting URL does not contain `p=10` and no redirect from a non-existent page occurs.

---

**Scenario 2 — Filter option hrefs do not contain the page parameter (no filter selected)**

1. Open a category listing page and navigate to a page beyond page 1 (e.g. `?p=4`).
2. Inspect the `href` attributes of filter options in the layered navigation (color, size, brand, etc.).
3. Verify that none of the filter option URLs contain a `p=` parameter.

---

**Scenario 3 — Filter option hrefs do not contain the page parameter (filter already selected)**

1. On a category page, select a filter (e.g. color = red), then navigate to page 2+ of the filtered results.
2. Inspect the `href` attributes of remaining filter options in the layered navigation.
3. Verify that the `p=` parameter is absent from all filter option URLs.

---

**Scenario 4 — Pagination still works normally**

1. Open any category listing page.
2. Navigate using the pagination controls (page 1, 2, 3, etc.).
3. Verify that `?p=N` is correctly applied and the correct products are shown for each page.

---