### PR TITLE
fix: add visibility filter to suggestions

### DIFF
--- a/Model/Autocomplete/DataProvider/SuggestionDataProvider.php
+++ b/Model/Autocomplete/DataProvider/SuggestionDataProvider.php
@@ -3,6 +3,7 @@
 namespace Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProvider;
 
 use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProviderHelper;
 use Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProviderInterface;
@@ -71,6 +72,7 @@ class SuggestionDataProvider implements DataProviderInterface
      * @param Client $client
      * @param Request $request
      * @param SuggestionBlockItemFactory $suggestionBlockItemFactory
+     * @param Visibility $visibility
      */
     public function __construct(
         Config $config,
@@ -81,7 +83,8 @@ class SuggestionDataProvider implements DataProviderInterface
         RequestFactory $suggestionRequestFactory,
         Client $client,
         Request $request,
-        protected readonly SuggestionBlockItemFactory $suggestionBlockItemFactory
+        protected readonly SuggestionBlockItemFactory $suggestionBlockItemFactory,
+        protected readonly Visibility $visibility
     ) {
         $this->config = $config;
         $this->cookieManager = $cookieManager;
@@ -189,6 +192,7 @@ class SuggestionDataProvider implements DataProviderInterface
         $request->setSearch($query);
         $this->addProfileKeyToRequest($request, $profileKeyCookie);
         $request->addCategoryFilter($category);
+        $this->addVisibilityFilter($request);
 
         return $request;
     }
@@ -209,8 +213,26 @@ class SuggestionDataProvider implements DataProviderInterface
         $request->setSearch($query);
         $this->addProfileKeyToRequest($request, $profileKeyCookie);
         $request->addCategoryFilter($category);
+        $this->addVisibilityFilter($request);
 
         return $request;
+    }
+
+    /**
+     * Add visibility filter to the request using tn_parameters, matching the search visibility filter behaviour.
+     *
+     * @param Request $request
+     * @return void
+     */
+    private function addVisibilityFilter(Request $request): void
+    {
+        $visibilityAttribute = $this->config->isGroupedProductsEnabled()
+            ? sprintf('parent_%s', 'visibility')
+            : 'visibility';
+
+        foreach ($this->visibility->getVisibleInSearchIds() as $visibilityValue) {
+            $request->addHiddenParameter($visibilityAttribute, $visibilityValue);
+        }
     }
 
     /**

--- a/Model/Autocomplete/DataProvider/SuggestionDataProvider.php
+++ b/Model/Autocomplete/DataProvider/SuggestionDataProvider.php
@@ -3,7 +3,6 @@
 namespace Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProvider;
 
 use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProviderHelper;
 use Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProviderInterface;
@@ -72,7 +71,6 @@ class SuggestionDataProvider implements DataProviderInterface
      * @param Client $client
      * @param Request $request
      * @param SuggestionBlockItemFactory $suggestionBlockItemFactory
-     * @param Visibility $visibility
      */
     public function __construct(
         Config $config,
@@ -83,8 +81,7 @@ class SuggestionDataProvider implements DataProviderInterface
         RequestFactory $suggestionRequestFactory,
         Client $client,
         Request $request,
-        protected readonly SuggestionBlockItemFactory $suggestionBlockItemFactory,
-        protected readonly Visibility $visibility
+        protected readonly SuggestionBlockItemFactory $suggestionBlockItemFactory
     ) {
         $this->config = $config;
         $this->cookieManager = $cookieManager;
@@ -226,13 +223,7 @@ class SuggestionDataProvider implements DataProviderInterface
      */
     private function addVisibilityFilter(Request $request): void
     {
-        $visibilityAttribute = $this->config->isGroupedProductsEnabled()
-            ? sprintf('parent_%s', 'visibility')
-            : 'visibility';
-
-        foreach ($this->visibility->getVisibleInSearchIds() as $visibilityValue) {
-            $request->addHiddenParameter($visibilityAttribute, $visibilityValue);
-        }
+        $this->dataProviderHelper->addVisibilityFilter($request);
     }
 
     /**

--- a/Model/Autocomplete/DataProviderHelper.php
+++ b/Model/Autocomplete/DataProviderHelper.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Layer\Category\CollectionFilter;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
+use Tweakwise\Magento2Tweakwise\Model\Client\Request;
 use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -76,6 +77,7 @@ class DataProviderHelper
      * @param ProductCollectionFactory $productCollectionFactory
      * @param CollectionFilter $collectionFilter
      * @param ProductItemFactory $productItemFactory
+     * @param CatalogConfig $catalogConfig
      */
     public function __construct(
         Config $config,
@@ -134,6 +136,24 @@ class DataProviderHelper
         $categoryId = $store->getRootCategoryId();
         // @phpstan-ignore-next-line
         return $this->categoryRepository->get($categoryId);
+    }
+
+    /**
+     * Add visibility filter to a suggestion request using tn_parameters,
+     * matching the search visibility filter behaviour in NavigationContext.
+     *
+     * @param Request $request
+     * @return void
+     */
+    public function addVisibilityFilter(Request $request): void
+    {
+        $visibilityAttribute = $this->config->isGroupedProductsEnabled()
+            ? 'parent_visibility'
+            : 'visibility';
+
+        foreach ([Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH] as $visibilityValue) {
+            $request->addHiddenParameter($visibilityAttribute, $visibilityValue);
+        }
     }
 
     /**

--- a/Model/Client/Request.php
+++ b/Model/Client/Request.php
@@ -40,6 +40,11 @@ class Request
     protected $parameters = [];
 
     /**
+     * @var array
+     */
+    protected $hiddenParameters = [];
+
+    /**
      * @var StoreManager
      */
     protected $storeManager;
@@ -160,6 +165,19 @@ class Request
         }
 
         return $this;
+    }
+
+    /**
+     * Add a hidden parameter encoded in tn_parameters, the same way Tweakwise navigation requests apply visibility filters.
+     *
+     * @param string $attribute
+     * @param int|string $value
+     * @return void
+     */
+    public function addHiddenParameter(string $attribute, $value): void
+    {
+        $this->hiddenParameters[] = sprintf('%s=%s', $attribute, $value);
+        $this->setParameter('tn_parameters', implode('&', $this->hiddenParameters));
     }
 
     /**

--- a/Model/Client/Request/ProductNavigationRequest.php
+++ b/Model/Client/Request/ProductNavigationRequest.php
@@ -30,11 +30,6 @@ class ProductNavigationRequest extends Request
     private const MAX_PRODUCTS = 1000;
 
     /**
-     * @var array
-     */
-    protected $hiddenParameters = [];
-
-    /**
      * {@inheritdoc}
      */
     public function getResponseType()
@@ -56,17 +51,6 @@ class ProductNavigationRequest extends Request
 
         $this->addParameter('tn_fk_' . $attribute, trim((string)$value));
         return $this;
-    }
-
-    /**
-     * @param string $attribute
-     * @param int $value
-     * @return void
-     */
-    public function addHiddenParameter(string $attribute, $value)
-    {
-        $this->hiddenParameters[] = sprintf('%s=%s', $attribute, $value);
-        $this->setParameter('tn_parameters', implode('&', $this->hiddenParameters));
     }
 
     /**


### PR DESCRIPTION
## Summary

- Added a visibility filter to the Tweakwise suggestion requests (`SuggestionsRequest` and `ProductSuggestionsRequest`), matching the existing behaviour of the search and navigation requests.
- Moved `$hiddenParameters` and `addHiddenParameter()` from `ProductNavigationRequest` up to the base `Request` class, so all request types can use the same `tn_parameters` encoding mechanism.
- The visibility filter uses `getVisibleInSearchIds()` (visibility 3 + 4), consistent with how `NavigationContext::addVisibilityFilter()` handles `ProductSearchRequest`.
- When grouped products are enabled, the filter is applied to `parent_visibility` instead of `visibility`, identical to the navigation/search behaviour.

## How to test

**Scenario 1 — Suggestions return only search-visible products**

1. Open the storefront search bar and type a query (e.g. `hood`).
2. Inspect the autocomplete network request to the Tweakwise suggestions endpoint (e.g. `/search/ajax/suggest/...?q=hood`).
3. Verify the Tweakwise API request contains `tn_parameters=visibility%3D3%26visibility%3D4` (or `parent_visibility=...` when grouped products are enabled).
4. Confirm that products not visible in search (visibility 1 — "Not Visible Individually", or visibility 2 — "Catalog") do not appear in the suggestion results.

---

**Scenario 2 — Grouped products mode applies parent_visibility**

1. Enable grouped products in the Tweakwise configuration (`Stores → Configuration → Tweakwise`). And do an full export and publish of the grouped products.
2. Repeat the steps from Scenario 1.
3. Verify the Tweakwise API request contains `tn_parameters=parent_visibility%3D3%26parent_visibility%3D4` instead of `visibility`.

---

**Scenario 3 — Navigation and search requests are unaffected**

1. Navigate to a category page and inspect the Tweakwise navigation request.
2. Verify `tn_parameters` still contains the catalog visibility values (`visibility=2&visibility=4`).
3. Perform a full search and verify the search request still contains the search visibility values (`visibility=3&visibility=4`).
4. Confirm no regression in product listing or search result pages.

---