### PR TITLE
fix: itemclick warnings

### DIFF
--- a/view/frontend/web/js/analytics.js
+++ b/view/frontend/web/js/analytics.js
@@ -19,6 +19,12 @@ define('Tweakwise_Magento2Tweakwise/js/analytics', ['jquery'], function($) {
                     }
 
                     if (!visual.length) {
+                        console.warn(
+                            '[Tweakwise] Could not track item click: no product element with selector ".' +
+                            config.productSelector +
+                            '" (with an id attribute) or ".visual" element found near the clicked element.',
+                            event.target
+                        );
                         return;
                     }
                 }
@@ -28,6 +34,10 @@ define('Tweakwise_Magento2Tweakwise/js/analytics', ['jquery'], function($) {
             }
 
             if (!productId) {
+                console.warn(
+                    '[Tweakwise] Could not track item click: product element found but id attribute is empty.',
+                    product || event.target
+                );
                 return;
             }
 


### PR DESCRIPTION
## Summary

- Add `console.warn` logging to the two silent return paths in `handleItemClick` in `analytics.js`
  where a product ID cannot be resolved.
- When neither the product container element (matched by `config.productSelector`) nor the `.visual`
  fallback can be found near the clicked element, a warning is logged including the configured CSS
  selector and the clicked DOM node.
- When the product container is found but its `id` attribute is missing or empty — the most common
  cause being a custom product-item template that omits the `id` attribute — a warning is logged
  including the element itself.
- All warnings are prefixed with `[Tweakwise]` for easy filtering in the browser console.

Previously these code paths returned silently, making it very difficult for integrating partners and
merchants to diagnose why item-click analytics were not being tracked.

## How to test

**Scenario 1 — Custom template missing the `id` attribute**

1. Open a category or search page that uses a custom product-item template without
   `id="product-item_<id>"` on the list item.
2. Open the browser DevTools console.
3. Click any product tile.
4. Verify a warning similar to the following appears:
   `[Tweakwise] Could not track item click: product element found but id attribute is empty.`
   The logged element should be the product container.

---

**Scenario 2 — Click outside any recognisable product element**

1. Open a category or search page with Tweakwise analytics enabled.
2. Open the browser DevTools console.
3. Click somewhere in the product list that is not inside a product tile or `.visual` element
   (e.g. a gap between tiles).
4. Verify a warning similar to the following appears:
   `[Tweakwise] Could not track item click: no product element with selector ".product-item" (with an id attribute) or ".visual" element found near the clicked element.`
   The logged element should be the exact DOM node that was clicked.

---

**Scenario 3 — Happy path still works**

1. Open a category or search page using the default Tweakwise product-item template.
2. Open the browser DevTools console.
3. Click a product tile.
4. Confirm **no** `[Tweakwise]` warnings appear in the console.
5. Confirm the item-click analytics request is sent (visible in the Network tab as a POST
   to the analytics endpoint).

---