### PR TITLE
fix: Removed resetPagination because it sets the response to null

### DIFF
--- a/Model/Catalog/Layer/ItemCollectionProvider.php
+++ b/Model/Catalog/Layer/ItemCollectionProvider.php
@@ -94,15 +94,7 @@ class ItemCollectionProvider implements ItemCollectionProviderInterface
         }
 
         try {
-            if (empty($this->navigationContext->getResponse()->getProductIds())) {
-                $collection = $this->collectionFactory
-                    ->create(['navigationContext' => $this->navigationContext->resetPagination()])
-                ;
-            } else {
-                $collection = $this->collectionFactory->create(['navigationContext' => $this->navigationContext]);
-            }
-
-            return $collection;
+            return $this->collectionFactory->create(['navigationContext' => $this->navigationContext]);
         } catch (TweakwiseExceptionInterface $e) {
             $this->log->critical($e);
             $this->config->setTweakwiseExceptionThrown();

--- a/Model/Catalog/Layer/NavigationContext.php
+++ b/Model/Catalog/Layer/NavigationContext.php
@@ -198,23 +198,6 @@ class NavigationContext
     }
 
     /**
-     * @return $this
-     */
-    public function resetPagination(): self
-    {
-        $params['resetPagination'] = true;
-        $params['tn_fk_p'] = 1;
-        $params['tn_p'] = 1;
-
-        // @phpstan-ignore-next-line
-        $this->request = null;
-        $this->request = $this->getRequest()->setParameters($params);
-        $this->response = null;
-
-        return $this;
-    }
-
-    /**
      * @param array $attributeCodes
      * @return Attribute[]
      */

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -492,7 +492,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
 
         $page = $this->getPage($request);
 
-        if ($page && (bool) $navigationRequest->getParameter('resetPagination') === false) {
+        if ($page) {
             $navigationRequest->setPage($page);
         }
 


### PR DESCRIPTION
The resetPagination function resets the response, causing the next call to make a new request. Due to the reset, it will then do this without a category ID, ensuring you return all products.