### PR TITLE
Fix: undefined index autocomplete

### DIFF
--- a/Model/Client/Response/AutocompleteResponse.php
+++ b/Model/Client/Response/AutocompleteResponse.php
@@ -82,6 +82,7 @@ class AutocompleteResponse extends Response implements AutocompleteProductRespon
                 'id' => $this->helper->getStoreId($item->getId()),
                 'tweakwise_price' => (float) $item->getPrice(),
                 'tweakwise_final_price' => (float) $item->getFinalPrice(),
+                'tweakwise_id' => $item->getId(),
             ];
         }
 


### PR DESCRIPTION
## Summary

- `AutocompleteResponse::getProductData()` was missing the `tweakwise_id` key in its returned item arrays, while `ProductSuggestionsResponse::getProductData()` already included it.
- `DataProviderHelper::getProductItems()` unconditionally reads `$item['tweakwise_id']` from the result of `getProductData()`, causing an undefined array key error in PHP 8.x when the legacy autocomplete API path was used (`tweakwise/autocomplete/use_suggestions` = `false`).
- Added `'tweakwise_id' => $item->getId()` to `AutocompleteResponse::getProductData()` to align both `AutocompleteProductResponseInterface` implementations.

## How to test

**Scenario 1 — Legacy autocomplete (use_suggestions disabled)**

1. In Magento admin, go to **Stores → Configuration → Tweakwise → Autocomplete** and set **Use Suggestions** to `No`.
2. Save the config and flush the cache.
3. Open the storefront and type a search query in the search bar.
4. Confirm autocomplete results appear without a PHP error or blank response.
5. Confirm product items in the autocomplete dropdown render correctly.

---

**Scenario 2 — Suggestions autocomplete (use_suggestions enabled)**

1. In Magento admin, set **Use Suggestions** back to `Yes`.
2. Save the config and flush the cache.
3. Open the storefront and type a search query in the search bar.
4. Confirm autocomplete results still appear correctly and no regression is introduced.

---