### PR TITLE
fix: return type

### DIFF
--- a/Model/FilterFormInputProvider/CategoryInputProvider.php
+++ b/Model/FilterFormInputProvider/CategoryInputProvider.php
@@ -118,8 +118,8 @@ class CategoryInputProvider implements FilterFormInputProviderInterface
 
         $input = [
             '__tw_ajax_type' => self::TYPE,
-            '__tw_object_id' => $this->getCategoryId(),
-            '__tw_original_url' => $url,
+            '__tw_object_id' => (int) $this->getCategoryId(),
+            '__tw_original_url' => (string) $url,
         ];
 
         $input['__tw_hash'] = $this->hashInputProvider->getHash($input);

--- a/Model/FilterFormInputProvider/FilterFormInputProviderInterface.php
+++ b/Model/FilterFormInputProvider/FilterFormInputProviderInterface.php
@@ -9,7 +9,7 @@ interface FilterFormInputProviderInterface
      * This is needed for ajax filtering. The array should be formatted as 'name' => 'value'
      * name will be rendered as name attribute in an <input> tag and obviously value will be its value attribute
      *
-     * @return string[]
+     * @return array
      */
-    public function getFilterFormInput();
+    public function getFilterFormInput(): array;
 }

--- a/Model/FilterFormInputProvider/ToolbarInputProvider.php
+++ b/Model/FilterFormInputProvider/ToolbarInputProvider.php
@@ -32,7 +32,7 @@ class ToolbarInputProvider implements FilterFormInputProviderInterface
     /**
      * @inheritDoc
      */
-    public function getFilterFormInput()
+    public function getFilterFormInput(): array
     {
         $input = [];
         foreach (self::TOOLBAR_INPUTS as $toolbarInput) {
@@ -44,7 +44,6 @@ class ToolbarInputProvider implements FilterFormInputProviderInterface
             $input[$toolbarInput] = filter_var($toolbarInputValue, FILTER_SANITIZE_ENCODED);
         }
 
-        // @phpstan-ignore-next-line
         return $input;
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a hash mismatch in `CategoryInputProvider::getFilterFormInput()` that caused AJAX filtering and pagination to silently fail (closes #354).
- The root cause: `__tw_object_id` was placed into the hash payload as `int|null`, but `HashInputProvider::validateHash()` always reconstructs it as `(int)` from the request param — so when `getCategoryId()` returned `null`, the serialized payloads differed and hash validation returned `false`.
- Fixed by casting `__tw_object_id` to `(int)` and `__tw_original_url` to `(string)` in `CategoryInputProvider`, making generation consistent with validation. This also matches the pattern already used correctly by `LandingPageInputProvider` in the bridge module.
- Added `: array` as a native return type to `FilterFormInputProviderInterface::getFilterFormInput()` and `ToolbarInputProvider` (all other implementations already declared it), replacing the inaccurate `@return string[]` docblock that misled implementors into the type mismatch in the first place.
- Removed a now-unnecessary `// @phpstan-ignore-next-line` from `ToolbarInputProvider`.

## How to test

**Scenario 1 — AJAX filtering works on a category page**

1. Enable Tweakwise layered navigation and AJAX filters in the admin (`tweakwise/layered/enabled`, `tweakwise/layered/ajax_filters`).
2. Open a category listing page (e.g. `/default/women/tops-women2/`).
3. Apply a filter using the layered navigation sidebar.
4. Verify the page updates via AJAX without a full reload and the correct filtered results are shown.
5. Verify no `InvalidArgumentException: Incorrect/modified form parameters` appears in `var/log/exception.log`.

---

**Scenario 2 — AJAX pagination works on a category page**

1. On the same category listing page with multiple result pages, click a pagination link.
2. Verify the page number changes via AJAX and the correct products are shown.
3. Verify no AJAX error or exception is logged.

---

**Scenario 3 — Landing page AJAX filtering still works**

1. Open a Tweakwise landing page that has AJAX filters enabled.
2. Apply a filter from the sidebar.
3. Verify the page updates via AJAX and returns the correct filtered results.
4. Verify no hash validation exception is logged.

---

**Scenario 4 — Search page AJAX filtering still works**

1. Perform a search that returns results with filterable facets.
2. Apply a filter from the sidebar.
3. Verify the page updates via AJAX correctly.

---