### PR TITLE
feat: Make client mockable

### DIFF
--- a/src/Model/Client.php
+++ b/src/Model/Client.php
@@ -108,6 +108,16 @@ class Client
         return $this->client;
     }
 
+    /**    
+     * Use for mocking with tests
+     * @param HttpClient $client
+     * @return void
+     */
+    public function setClient(HttpClient $client): void 
+    {
+        $this->client = $client;
+    }
+    
     /**
      * @param Request $tweakwiseRequest
      * @return HttpRequest


### PR DESCRIPTION
Make client mockable for testing. 

Now we need something like:

```
 $client = $this->tester->getObjectManager()->create(Client::class);
 $ref = new ReflectionProperty($client, 'client');
 $ref->setAccessible(true);
 $ref->setValue($client, $guzzle);

```

Would be much easier when we could:

```
 $client = $this->tester->getObjectManager()->create(Client::class);
 $client->setClient($guzzle);
```
