### PR TITLE
null suggestion handling

### DIFF
--- a/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
+++ b/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
@@ -27,9 +27,10 @@ class ProductSuggestionsResponse extends Response implements AutocompleteProduct
      */
     public function getProductData()
     {
+        $items = $this->getItems() ?? [];
         $result = [];
         // @phpstan-ignore-next-line
-        foreach ($this->getItems() as $item) {
+        foreach ($items as $item) {
             $result[] = [
                 'id' => $this->helper->getStoreId($item->getId()),
                 'tweakwise_price' => (float) $item->getPrice(),


### PR DESCRIPTION
null suggestions will cause run time exception..

<domain>/search/ajax/suggest?q=somethingwithoutsuggestion
`
Magento\Framework\App\ErrorHandler::handler()
/vendor/tweakwise/magento2-tweakwise/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php:32
Tweakwise\Magento2Tweakwise\Model\Client\Response\Suggestions\ProductSuggestionsResponse::getProductData()
/vendor/tweakwise/magento2-tweakwise/Model/Autocomplete/DataProviderHelper.php:191
Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProviderHelper::getProductItems()
/vendor/tweakwise/magento2-tweakwise/Model/Autocomplete/DataProvider/SuggestionDataProvider.php:258
Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProvider\SuggestionDataProvider::processResponse()
/vendor/tweakwise/magento2-tweakwise/Model/Autocomplete/DataProvider/SuggestionDataProvider.php:126
Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProvider\SuggestionDataProvider::getItems()
/vendor/tweakwise/magento2-tweakwise/Model/Autocomplete/DataProvider.php:44
Tweakwise\Magento2Tweakwise\Model\Autocomplete\DataProvider::getItems()
`