### PR TITLE
Prevent Tweakwise autocomplete foreach-on-null warning

### DIFF
--- a/src/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
+++ b/src/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
@@ -29,7 +29,7 @@ class ProductSuggestionsResponse extends Response implements AutocompleteProduct
     {
         $result = [];
         // @phpstan-ignore-next-line
-        foreach ($this->getItems() as $item) {
+        foreach ($this->getItems() ?? [] as $item) {
             $result[] = [
                 'id' => $this->helper->getStoreId($item->getId()),
                 'tweakwise_price' => (float) $item->getPrice(),


### PR DESCRIPTION
 getProductData() triggers "Warning: foreach() argument must be of type array|object, null given" whenever the suggestions API returns no product suggestions, since getItems() resolves to null via the magic getter. This adds the same null guard that getProductIds() in the same class already has. Seen in production on v9.0.1 via search/ajax/suggest; still present on master.